### PR TITLE
Lets add the method validate and sanitize method

### DIFF
--- a/src/Aura/Filter/AbstractRule.php
+++ b/src/Aura/Filter/AbstractRule.php
@@ -210,4 +210,28 @@ abstract class AbstractRule implements RuleInterface
         // strings that trim down to exactly nothing are blank
         return trim($value) === '';
     }
+
+    /**
+     *
+     * Make use of overriding, do we want to throw an exception here?
+     *
+     * @return bool true on success, or false on failure.
+     *
+     */
+    protected function validate()
+    {
+        return false;
+    }
+
+    /**
+     *
+     * Make use of overriding, do we want to throw an exception here?
+     *
+     * @return bool true on success, or false on failure.
+     *
+     */
+    protected function sanitize()
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
What will happen if the user forgets to create `validate()` and `sanitize()` method ?

As the method signature differs we cannot make use of it in Interface .
