### PR TITLE
It should be the other_field, I checked with ->addSoftRule('password', :...

### DIFF
--- a/intl/en_US.php
+++ b/intl/en_US.php
@@ -58,11 +58,11 @@ return array(
         "FILTER_RULE_FAILURE_FIX_EMAIL" => "Could not sanitize to an email address.",
         "FILTER_RULE_FAILURE_FIX_BLANK_OR_EMAIL" => "Could not sanitize to blank or a valid email address.",
 
-        "FILTER_RULE_FAILURE_IS_EQUAL_TO_FIELD" => "Please use a value equal to the field '{field}'.",
-        "FILTER_RULE_FAILURE_IS_NOT_EQUAL_TO_FIELD" => "Please do not use a value equal to the field '{field}'.",
-        "FILTER_RULE_FAILURE_IS_BLANK_OR_EQUAL_TO_FIELD" => "Please leave blank or use a value equal to the field '{field}'.",
-        "FILTER_RULE_FAILURE_FIX_EQUAL_TO_FIELD" => "Could not sanitize to a value equal to the field '{field}'.",
-        "FILTER_RULE_FAILURE_FIX_BLANK_OR_EQUAL_TO_FIELD" => "Could not sanitize to blank or a value equal to the field '{field}'.",
+        "FILTER_RULE_FAILURE_IS_EQUAL_TO_FIELD" => "Please use a value equal to the field '{other_field}'.",
+        "FILTER_RULE_FAILURE_IS_NOT_EQUAL_TO_FIELD" => "Please do not use a value equal to the field '{other_field}'.",
+        "FILTER_RULE_FAILURE_IS_BLANK_OR_EQUAL_TO_FIELD" => "Please leave blank or use a value equal to the field '{other_field}'.",
+        "FILTER_RULE_FAILURE_FIX_EQUAL_TO_FIELD" => "Could not sanitize to a value equal to the field '{other_field}'.",
+        "FILTER_RULE_FAILURE_FIX_BLANK_OR_EQUAL_TO_FIELD" => "Could not sanitize to blank or a value equal to the field '{other_field}'.",
 
         "FILTER_RULE_FAILURE_IS_EQUAL_TO_VALUE" => "Please use the value '{value}'.",
         "FILTER_RULE_FAILURE_IS_NOT_EQUAL_TO_VALUE" => "Please do not use the value '{value}'.",


### PR DESCRIPTION
...:IS, 'strlenMin', 6);

@pmjones, I also feel like as we added the translation message does that limit users to use the default translator. 

May be we need an option to show the labels itself than the message taken from the intl .

So say if the filter has a flag it will show the string, else label. Let by default it be string message.

Thoughts ?
