### PR TITLE
Fix the bug in any

### DIFF
--- a/src/Aura/Filter/Rule/Any.php
+++ b/src/Aura/Filter/Rule/Any.php
@@ -66,6 +66,18 @@ class Any extends AbstractRule
     
     /**
      * 
+     * Returns the rule locator.
+     * 
+     * @return RuleLocator
+     * 
+     */
+    public function getRuleLocator()
+    {
+        return $this->rule_locator;
+    }
+    
+    /**
+     * 
      * Validates that the value passes at least one the rules in a list.
      * 
      * @param array $list The list of rules that the value must pass.

--- a/tests/Aura/Filter/RuleCollectionTest.php
+++ b/tests/Aura/Filter/RuleCollectionTest.php
@@ -395,4 +395,21 @@ class RuleCollectionTest extends \PHPUnit_Framework_TestCase
         $actual = $instance->getRuleLocator()->get('any');
         $this->assertInstanceOf($expect, $actual);
     }
+    
+    public function testNewRuleInAny()
+    {
+        $instance = require dirname(dirname(dirname(__DIR__))) . '/scripts/instance.php';
+        $any = $instance->getRuleLocator()->get('any');
+        $any->getRuleLocator()->set('hex', function () {
+            return new \Aura\Filter\Rule\Hex;
+        });
+        $instance->addSoftRule('hexval', $instance::IS, 'any', [
+                ['hex']
+            ]
+        );
+        $data = (object) [
+            'hexval' => 'abcdef',
+        ];
+        $this->assertTrue($instance->values($data));
+    }
 }


### PR DESCRIPTION
Bug reported in groups when the any field have some custom rule.

https://groups.google.com/d/msg/auraphp/6pr5nG2_1uM/35umofI2f5AJ

The problem here is when new rules are added the `RuleLocator` for the `any` is different than that of the normal.

So we need to get the `RuleLocator` of `any` first and set it.

This can be addressed via `di` , but for those who are using `scripts/instance.php` should have a way to get and add to the rule locator.
