### PR TITLE
unicode tests fixes and strpad added

### DIFF
--- a/src/Rule/AbstractStrlen.php
+++ b/src/Rule/AbstractStrlen.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  *
  * This file is part of Aura for PHP.
@@ -6,6 +7,7 @@
  * @license http://opensource.org/licenses/bsd-license.php BSD
  *
  */
+
 namespace Aura\Filter\Rule;
 
 /**
@@ -15,21 +17,22 @@ namespace Aura\Filter\Rule;
  * @package Aura.Filter
  *
  */
-abstract class AbstractStrlen
-{
+abstract class AbstractStrlen {
+
     /**
      *
      * Proxy to `mb_strlen()` when it exists, otherwise to `strlen()`.
      *
      * @param string $str Returns the length of this string.
      *
+     * @param string $encoding The encoding used, UTF-8 by default
+     *
      * @return int
      *
      */
-    protected function strlen($str)
-    {
+    protected function strlen($str, $encoding = "UTF-8") {
         if (function_exists('mb_strlen')) {
-            return mb_strlen($str);
+            return mb_strlen($str, $encoding);
         }
         return strlen($str);
     }
@@ -44,14 +47,61 @@ abstract class AbstractStrlen
      *
      * @param int $length End after this many characters.
      *
+     * @param string $encoding The encoding used, UTF-8 by default
+     *
      * @return string
      *
      */
-    protected function substr($str, $start, $length = null)
-    {
+    protected function substr($str, $start, $length = null, $encoding = "UTF-8") {
         if (function_exists('mb_substr')) {
-            return mb_substr($str, $start, $length);
+            return mb_substr($str, $start, $length, $encoding);
         }
         return substr($str, $start, $length);
     }
+
+    /**
+     *
+     * We need another function for str_padding
+     *
+     * @param string $input The string to work with.
+     *
+     * @param int $length How much symbols do we want it to be
+     *
+     * @param string $pad_str What are we going to pad it with
+     *
+     * @param int $type Where should it be padded - left,right or both
+     *
+     * @param string $encoding The encoding used, UTF-8 by default
+     *
+     * @return string
+     *
+     */
+    protected function str_pad($input, $length, $pad_str = " ", $type = STR_PAD_RIGHT, $encoding = "UTF-8") {
+        //return str_pad($str, strlen($str)-$this->strlen($str,$encoding)+$pad_length, $pad_string, $pad_type);
+
+        $input_len = $this->strlen($input,$encoding);
+        if ($length <= $input_len)
+            return $input;
+        $pad_str_len = $this->strlen($pad_str,$encoding);
+        $pad_len = $length - $input_len;
+        if ($type == STR_PAD_RIGHT) {
+            $repeat_times = ceil($pad_len / $pad_str_len);
+            return $this->substr($input . str_repeat($pad_str, $repeat_times), 0, $length,$encoding);
+        }
+        if ($type == STR_PAD_LEFT) {
+            $repeat_times = ceil($pad_len / $pad_str_len);
+            return $this->substr(str_repeat($pad_str, $repeat_times), 0, floor($pad_len),$encoding) . $input;
+        }
+        if ($type == STR_PAD_BOTH) {
+            $pad_len /= 2;
+            $pad_amount_left = floor($pad_len);
+            $pad_amount_right = ceil($pad_len);
+            $repeat_times_left = ceil($pad_amount_left / $pad_str_len);
+            $repeat_times_right = ceil($pad_amount_right / $pad_str_len);
+            $padding_left = $this->substr(str_repeat($pad_str, $repeat_times_left), 0, $pad_amount_left,$encoding);
+            $padding_right = $this->substr(str_repeat($pad_str, $repeat_times_right), 0, $pad_amount_right,$encoding);
+            return $padding_left . $input . $padding_right;
+        }
+    }
+
 }

--- a/src/Rule/Sanitize/Strlen.php
+++ b/src/Rule/Sanitize/Strlen.php
@@ -43,7 +43,7 @@ class Strlen extends AbstractStrlen
             return false;
         }
         if ($this->strlen($value) < $len) {
-            $subject->$field = str_pad($value, $len, $pad_string, $pad_type);
+            $subject->$field = $this->str_pad($value, $len, $pad_string, $pad_type);
         }
         if ($this->strlen($value) > $len) {
             $subject->$field = $this->substr($value, 0, $len);

--- a/src/Rule/Sanitize/StrlenBetween.php
+++ b/src/Rule/Sanitize/StrlenBetween.php
@@ -45,7 +45,7 @@ class StrlenBetween extends AbstractStrlen
             return false;
         }
         if ($this->strlen($value) < $min) {
-            $subject->$field = str_pad($value, $min, $pad_string, $pad_type);
+            $subject->$field = $this->str_pad($value, $min, $pad_string, $pad_type);
         }
         if ($this->strlen($value) > $max) {
             $subject->$field = $this->substr($value, 0, $max);

--- a/src/Rule/Sanitize/StrlenMin.php
+++ b/src/Rule/Sanitize/StrlenMin.php
@@ -43,7 +43,7 @@ class StrlenMin extends AbstractStrlen
             return false;
         }
         if ($this->strlen($value) < $min) {
-            $subject->$field = str_pad($value, $min, $pad_string, $pad_type);
+            $subject->$field = $this->str_pad($value, $min, $pad_string, $pad_type);
         }
         return true;
     }

--- a/tests/Rule/Sanitize/StrlenMaxTest.php
+++ b/tests/Rule/Sanitize/StrlenMaxTest.php
@@ -18,7 +18,7 @@ class StrlenMaxTest extends AbstractSanitizeTest
             array('abc',     true, 'abc'),
             array('abcd',    true, 'abc'),
             array('abcdefg', true, 'abc'),
-            array('а',       true, 'а'),
+            array('ж',       true, 'ж'),
             array('абв',     true, 'абв'),
             array('абвг',    true, 'абв'),
             array('абвгдеж', true, 'абв'),

--- a/tests/Rule/Sanitize/StrlenMinTest.php
+++ b/tests/Rule/Sanitize/StrlenMinTest.php
@@ -18,7 +18,7 @@ class StrlenMinTest extends AbstractSanitizeTest
             array('a', true, 'a   '),
             array('abcd', true, 'abcd'),
             array('abcdefg', true, 'abcdefg'),
-            array('а', true, 'a   '),
+            array('г', true, 'г   '),
             array('абвг', true, 'абвг'),
             array('абвгдеж', true, 'абвгдеж'),
         );

--- a/tests/Rule/Sanitize/StrlenTest.php
+++ b/tests/Rule/Sanitize/StrlenTest.php
@@ -19,9 +19,9 @@ class StrlenTest extends AbstractSanitizeTest
             array('a', true, 'a   '),
             array('abcd', true, 'abcd'),
             array('abcdef', true, 'abcd'),
-            array('а', true, 'а   '),
+            array('ж', true, 'ж   '),
             array('абвг', true, 'абвг'),
-            array('абвгде', true, 'абвгде'),
+            array('абвгде', true, 'абвг'),
         );
     }
 }


### PR DESCRIPTION
Sorry for messing the whitespace formatting of the code. Seems my IDE is not compliant with it.

Comit msg: We shouldn't use 'а' in cyrillic as an only character as it's indistinguishable from 'a' in latin
added a str_pad function proxy as there is no mb_str_pad function available.
also $encoding to all the new functions, so we don't depend on the default encoding.
set as param with default value of UTF-8
