### PR TITLE
Iconv_substr should have a proxy function for malformed exception as well.

### DIFF
--- a/src/Rule/AbstractStrlen.php
+++ b/src/Rule/AbstractStrlen.php
@@ -67,6 +67,34 @@ abstract class AbstractStrlen
         return strlen(utf8_decode($str));
     }
 
+     /**
+     *
+     * Wrapper for `iconv_substr()` to throw an exception on malformed UTF-8.
+     *
+     * @param string $str The string to work with.
+     *
+     * @param int $start Start at this position.
+     *
+     * @param int $length End after this many characters.
+     *
+     * @return int
+     *
+     * @throws Exception\MalformedUtf8
+     *
+     */
+    protected function substrIconv($str,$start,$length)
+    {
+        $level = error_reporting(0);
+        $substr = iconv_substr($str,$start,$length, 'UTF-8');
+        error_reporting($level);
+
+        if ($substr !== false) {
+            return $substr;
+        }
+
+        throw new Exception\MalformedUtf8();
+    }
+    
     /**
      *
      * Wrapper for `iconv_strlen()` to throw an exception on malformed UTF-8.
@@ -108,7 +136,7 @@ abstract class AbstractStrlen
     protected function substr($str, $start, $length = null)
     {
         if ($this->iconv()) {
-            return iconv_substr($str, $start, $length, 'UTF-8');
+            return $this->substrIconv($str, $start, $length);
         }
 
         if ($this->mbstring()) {

--- a/src/Rule/AbstractStrlen.php
+++ b/src/Rule/AbstractStrlen.php
@@ -77,7 +77,7 @@ abstract class AbstractStrlen
      *
      * @param int $length End after this many characters.
      *
-     * @return int
+     * @return string
      *
      * @throws Exception\MalformedUtf8
      *

--- a/tests/Rule/StrlenTest.php
+++ b/tests/Rule/StrlenTest.php
@@ -46,12 +46,20 @@ class StrlenTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expect, $actual);
     }
 
-    public function testIconvMalformedUtf8()
+    public function testIconvStrlenMalformedUtf8()
     {
         $bad = "\xFF\xFE";
         $fake = new FakeStrlenIconv();
         $this->setExpectedException('Aura\Filter\Exception\MalformedUtf8');
-        $fake->strlen($bad);
+        $fake->strlen($bad); 
+    }
+    
+    public function testIconvSubstrMalformedUtf8()
+    {
+        $bad = "\xFF\xFE";
+        $fake = new FakeStrlenIconv();
+        $this->setExpectedException('Aura\Filter\Exception\MalformedUtf8');
+        $fake->substr($bad,0,1); 
     }
 
     public function fakeProvider()


### PR DESCRIPTION
Added a proxy function for iconv_substr to throw an MalformedUtf8 exception if needed. Second commit fixed a typo in the comments for the function.
