### PR TITLE
Filtering a missing field

### DIFF
--- a/src/Spec/SanitizeSpec.php
+++ b/src/Spec/SanitizeSpec.php
@@ -149,7 +149,7 @@ class SanitizeSpec extends Spec
     {
         if($safe_rand === 2 && function_exists('openssl_random_pseudo_bytes')) 
         {
-            $res_str = base64_encode(openssl_random_pseudo_bytes($len*16,true)) ;
+            $res_str = base64_encode(openssl_random_pseudo_bytes($len*16)) ;
         }
         else
         {

--- a/src/Spec/SanitizeSpec.php
+++ b/src/Spec/SanitizeSpec.php
@@ -49,6 +49,7 @@ class SanitizeSpec extends Spec
     public function to($rule)
     {
         $this->allow_blank = false;
+        $this->allow_null = false;
         return $this->init(func_get_args());
     }
 
@@ -66,6 +67,7 @@ class SanitizeSpec extends Spec
     public function toBlankOr($rule)
     {
         $this->allow_blank = true;
+        $this->allow_null = false;
         return $this->init(func_get_args());
     }
     

--- a/src/Spec/SanitizeSpec.php
+++ b/src/Spec/SanitizeSpec.php
@@ -59,6 +59,23 @@ class SanitizeSpec extends Spec
         $this->allow_blank = true;
         return $this->init(func_get_args());
     }
+    
+        /**
+     *
+     * Sanitize the using this rule (null allowed).
+     *
+     * @param string $rule The rule name.
+     *
+     * @param ...$args Arguments for the rule.
+     *
+     * @return self
+     *
+     */
+    public function toNullOr($rule)
+    {
+        $this->allow_null = true;
+        return $this->init(func_get_args());
+    }
 
     /**
      *
@@ -74,6 +91,27 @@ class SanitizeSpec extends Spec
         $this->allow_blank = true;
         $this->blank_value = $blank_value;
         return $this;
+    }
+    
+    
+       /**
+     *
+     * Check if the field is allowed to be, and actually is, blank.
+     *
+     * @param mixed $subject The filter subject.
+     *
+     * @return bool
+     *
+     */
+    protected function applyNull($subject)
+    {
+        if (! parent::applyNull($subject)) {
+            return false;
+        }
+
+        $field = $this->field;
+        $subject->$field = null;
+        return true;
     }
 
     /**

--- a/src/Spec/SanitizeSpec.php
+++ b/src/Spec/SanitizeSpec.php
@@ -25,6 +25,15 @@ class SanitizeSpec extends Spec
      *
      */
     protected $blank_value;
+    
+        /**
+     *
+     * If the field is null, use this as the replacement value.
+     *
+     * @param mixed
+     *
+     */
+    protected $null_value;
 
     /**
      *
@@ -93,6 +102,22 @@ class SanitizeSpec extends Spec
         return $this;
     }
     
+        /**
+     *
+     * Use this value for null fields.
+     *
+     * @param mixed $null_value Replace the blank field with this value.
+     *
+     * @return self
+     *
+     */
+    public function useNullValue($null_value)
+    {
+        $this->allow_null = true;
+        $this->null_value = $null_value;
+        return $this;
+    }
+    
     
        /**
      *
@@ -110,7 +135,7 @@ class SanitizeSpec extends Spec
         }
 
         $field = $this->field;
-        $subject->$field = null;
+        $subject->$field =  $this->null_value;
         return true;
     }
 

--- a/src/Spec/Spec.php
+++ b/src/Spec/Spec.php
@@ -79,6 +79,15 @@ class Spec
      *
      */
     protected $allow_blank = false;
+    
+        /**
+     *
+     * Allow the field to be null?
+     *
+     * @var bool
+     *
+     */
+    protected $allow_null = false;
 
     /**
      *
@@ -123,7 +132,7 @@ class Spec
      */
     public function __invoke($subject)
     {
-        return $this->applyBlank($subject)
+        return $this->applyBlank($subject) || $this->applyNull($subject)
             || $this->applyRule($subject);
     }
 
@@ -326,6 +335,31 @@ class Spec
         return $message;
     }
 
+        /**
+     *
+     * Check if the field is allowed to be, and actually is, blank.
+     *
+     * @param mixed $subject The filter subject.
+     *
+     * @return bool
+     *
+     */
+    protected function applyNull($subject)
+    {
+        if (! $this->allow_null) {
+            return false;
+        }
+
+        // the field name
+        $field = $this->field;
+
+        // not set, or null, means it is blank
+        if (! isset($subject->$field) || $subject->$field === null) {
+            return true;
+        }
+        return false;
+    }
+    
     /**
      *
      * Check if the field is allowed to be, and actually is, blank.

--- a/src/Spec/Spec.php
+++ b/src/Spec/Spec.php
@@ -403,10 +403,21 @@ class Spec
      */
     protected function applyRule($subject)
     {
+        $added = false;
         $rule = $this->locator->get($this->rule);
         $args = $this->args;
         array_unshift($args, $this->field);
         array_unshift($args, $subject);
-        return call_user_func_array($rule, $args);
+        if(!isset($subject->{$this->field}) && !property_exists($subject,$this->field))
+        {
+                 $subject->{$this->field} = null;
+                 $added = true;
+        }
+       
+        $result = call_user_func_array($rule, $args);
+        if($added && property_exists($subject,$this->field) && $subject->{$this->field} === null) {
+            unset($subject->{$this->field});
+        }
+        return $result;
     }
 }

--- a/src/Spec/ValidateSpec.php
+++ b/src/Spec/ValidateSpec.php
@@ -61,6 +61,24 @@ class ValidateSpec extends Spec
         $this->reverse = false;
         return $this->init(func_get_args());
     }
+    
+        /**
+     *
+     * Validate the field matches this rule (blank allowed).
+     *
+     * @param string $rule The rule name.
+     *
+     * @param ...$args Arguments for the rule.
+     *
+     * @return self
+     *
+     */
+    public function isNullOr($rule)
+    {
+        $this->allow_null = true;
+        $this->reverse = false;
+        return $this->init(func_get_args());
+    }
 
     /**
      *
@@ -110,6 +128,9 @@ class ValidateSpec extends Spec
         $message = $this->field . ' should';
         if ($this->allow_blank) {
             $message .= ' have been blank or';
+        }  
+        if ($this->allow_null) {
+            $message .= ' have been null or';
         }
         if ($this->reverse) {
             $message .= ' not';

--- a/src/Spec/ValidateSpec.php
+++ b/src/Spec/ValidateSpec.php
@@ -40,6 +40,7 @@ class ValidateSpec extends Spec
     public function is($rule)
     {
         $this->allow_blank = false;
+        $this->allow_null = false;
         $this->reverse = false;
         return $this->init(func_get_args());
     }
@@ -58,6 +59,7 @@ class ValidateSpec extends Spec
     public function isBlankOr($rule)
     {
         $this->allow_blank = true;
+        $this->allow_null = false;
         $this->reverse = false;
         return $this->init(func_get_args());
     }
@@ -94,6 +96,7 @@ class ValidateSpec extends Spec
     public function isNot($rule)
     {
         $this->allow_blank = false;
+        $this->allow_null = false;
         $this->reverse = true;
         return $this->init(func_get_args());
     }
@@ -112,6 +115,7 @@ class ValidateSpec extends Spec
     public function isBlankOrNot($rule)
     {
         $this->allow_blank = true;
+        $this->allow_null = false;
         $this->reverse = true;
         return $this->init(func_get_args());
     }

--- a/tests/Spec/SanitizeSpecTest.php
+++ b/tests/Spec/SanitizeSpecTest.php
@@ -58,6 +58,34 @@ class SanitizeSpecTest extends \PHPUnit_Framework_TestCase
         $expect = 'foo should have sanitized to strlen(3)';
         $this->assertSame($expect, $this->spec->getMessage());
     }
+    
+    public function testToNullOr()
+    {
+        $this->spec->field('foo')->toNullOr('strlen', 3);
+
+        $subject = (object) array();
+        $this->assertTrue($this->spec->__invoke($subject));
+
+        $subject->foo = null;
+        $this->assertTrue($this->spec->__invoke($subject));
+
+        $subject->foo = 'zimgir';
+        $this->assertTrue($this->spec->__invoke($subject));
+        $this->assertSame('zim', $subject->foo);
+        
+        
+        $subject->foo = '   ';
+        $this->assertTrue($this->spec->__invoke($subject));
+        $this->assertSame('   ', $subject->foo);
+        
+         $subject->foo = '';
+        $this->assertTrue($this->spec->__invoke($subject));
+        $this->assertSame('   ', $subject->foo);
+
+
+        $subject->foo = array();
+        $this->assertFalse($this->spec->__invoke($subject));
+    }
 
     public function testToBlankOr()
     {
@@ -71,6 +99,14 @@ class SanitizeSpecTest extends \PHPUnit_Framework_TestCase
 
         $subject->foo = 'zimgir';
         $this->assertTrue($this->spec->__invoke($subject));
+        
+        $subject->foo = '   ';
+        $this->assertTrue($this->spec->__invoke($subject));
+        $this->assertSame(null, $subject->foo);
+        
+         $subject->foo = '';
+        $this->assertTrue($this->spec->__invoke($subject));
+        $this->assertSame(null, $subject->foo);
 
         $subject->foo = array();
         $this->assertFalse($this->spec->__invoke($subject));

--- a/tests/Spec/ValidateSpecTest.php
+++ b/tests/Spec/ValidateSpecTest.php
@@ -90,12 +90,48 @@ class ValidateSpecTest extends \PHPUnit_Framework_TestCase
 
         $subject->foo = 'bar';
         $this->assertTrue($this->spec->__invoke($subject));
+        
+        $subject->foo = '';
+        $this->assertTrue($this->spec->__invoke($subject));
+        
+        $subject->foo = '   ';
+        $this->assertTrue($this->spec->__invoke($subject));
 
         $subject->foo = 'zimgir';
         $this->assertFalse($this->spec->__invoke($subject));
         $expect = 'foo should have been blank or have validated as strlen(3)';
         $actual = $this->spec->getMessage();
         $this->assertSame($expect, $actual);
+    }
+    
+    public function testIsNullOr()
+    {
+        $this->spec->field('foo')->isNullOr('strlen', 3);
+
+        $subject = (object) array();
+        $this->assertTrue($this->spec->__invoke($subject));
+
+        $subject->foo = null;
+        $this->assertTrue($this->spec->__invoke($subject));
+
+        $subject->foo = 123;
+        $this->assertTrue($this->spec->__invoke($subject));
+
+        $subject->foo = 'bar';
+        $this->assertTrue($this->spec->__invoke($subject));
+
+        $subject->foo = 'zimgir';
+        $this->assertFalse($this->spec->__invoke($subject));
+        $expect = 'foo should have been null or have validated as strlen(3)';
+        $actual = $this->spec->getMessage();
+        $this->assertSame($expect, $actual);
+        
+        $subject->foo = '';
+        $this->assertFalse($this->spec->__invoke($subject));
+        $expect = 'foo should have been null or have validated as strlen(3)';
+        $actual = $this->spec->getMessage();
+        $this->assertSame($expect, $actual);
+        
     }
 
 

--- a/tests/SubjectFilterTest.php
+++ b/tests/SubjectFilterTest.php
@@ -156,14 +156,26 @@ class SubjectFilterTest extends \PHPUnit_Framework_TestCase
             $this->assertSame($expect, $actual);
         }
     }
+    
+        public function testApply_onObject()
+    {
+        $this->filter->sanitize('foo')->to('strlenMax', 3);
+        $this->filter->sanitize('bar')->to('remove');
+        $this->filter->sanitize('qbar')->to('int');
+        $array = new \stdClass();
+        $array->foo='123456';
+        $result = $this->filter->apply($array);
+        $this->assertFalse($result);
+    }
 
     public function testApply_onArray()
     {
         $this->filter->sanitize('foo')->to('strlenMax', 3);
         $this->filter->sanitize('bar')->to('remove');
+        $this->filter->sanitize('qbar')->to('int');
         $array = array('foo' => '123456', 'bar' => 'remove-me');
         $result = $this->filter->apply($array);
-        $this->assertTrue($result);
+        $this->assertFalse($result);
         $expect = array('foo' => '123');
         $this->assertSame($expect, $array);
     }


### PR DESCRIPTION
Bugfix for missing properties(current version has no checks for such) + a new method for instead of _Blank_, just _Null_ since sometimes we'd rather treat null and '' as two distinct things.
