### PR TITLE
Change @return in docblock for newSubjectFilter

### DIFF
--- a/src/FilterFactory.php
+++ b/src/FilterFactory.php
@@ -66,7 +66,7 @@ class FilterFactory
      *
      * @param string $class The filter class to instantiate.
      *
-     * @return Filter
+     * @return SubjectFilter
      *
      */
     public function newSubjectFilter($class = 'Aura\Filter\SubjectFilter')


### PR DESCRIPTION
Specifying the return as Filter seems incorrect and also causes issues with IDEs (PHPStorm) reporting "Method not found in Aura\Filter\Filter" when trying to use it.
