### PR TITLE
[3.x] Feature: PSR-7 upload validator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "ext-libxml": "*"
+        "ext-libxml": "*",
+        "psr/http-message": "~1.0"
     },
     "autoload": {
         "psr-4": {
@@ -30,6 +31,9 @@
         "ext-iconv": "To support UTF-8 in string-length filters.",
         "ext-intl": "To support IDNs in email filters.",
         "ext-mbstring": "To support UTF-8 in string-length filters."
+    },
+    "require-dev": {
+         "zendframework/zend-diactoros": "~1.0"
     },
     "autoload-dev": {
         "psr-4": {

--- a/docs/sanitize.md
+++ b/docs/sanitize.md
@@ -207,6 +207,15 @@ Sanitizes the value to `trim()` it. Optionally specify characters to trim.
 $filter->sanitize('field')->to('trim', $chars);
 ```
 
+## uploadedFileOrNull
+
+Sanitizes the value to `null` if value is not an instance of PSR7
+UploadedFileInterface or file was not uploaded
+
+```php
+$filter->sanitize('field')->to('uploadedFileOrNull');
+```
+
 ## uppercase
 
 Sanitizes the value to all uppercase characters.

--- a/docs/sanitize.md
+++ b/docs/sanitize.md
@@ -98,7 +98,7 @@ $filter->sanitize('field')->to('isbn');
 
 Sanitizes the value to all lowercase characters.
 
-```
+```php
 $filter->sanitize('field')->to('lowercase');
 ```
 
@@ -106,7 +106,7 @@ $filter->sanitize('field')->to('lowercase');
 
 Sanitizes the value to begin with a lowercase character.
 
-```
+```php
 $filter->sanitize('field')->to('lowercaseFirst');
 ```
 
@@ -220,7 +220,7 @@ $filter->sanitize('field')->to('uploadedFileOrNull');
 
 Sanitizes the value to all uppercase characters.
 
-```
+```php
 $filter->sanitize('field')->to('uppercase');
 ```
 
@@ -228,7 +228,7 @@ $filter->sanitize('field')->to('uppercase');
 
 Sanitizes the value to begin with an uppercase character.
 
-```
+```php
 $filter->sanitize('field')->to('uppercaseFirst');
 ```
 

--- a/docs/validate.md
+++ b/docs/validate.md
@@ -290,6 +290,23 @@ Validates the value represents a PHP upload information array, and that the file
 $filter->validate('field')->is('upload');
 ```
 
+## uploadedFile
+
+Validates the presence and properites of a PSR7 UploadedFileInterface
+
+```php
+$filter->validate('field')->is(
+    'uploadedFile',
+    [
+        'required' => true, // require the file be uploaded
+        'fileExtension' => ['txt', 'pdf'], // string or array of acceptable extensions
+        'fileMedia' => ['text/plain', 'application/pdf'], // string or array of acceptable media types
+        'sizeMin' => 1024, // size as numeric bytes or human readable string with units: KB, MB, GB, TB, PB
+        'sizeMax' => '2MB', // size as numeric bytes or human readable string with units: KB, MB, GB, TB, PB
+    ]
+);
+```
+
 ## uppercase
 
 Validates the value as all uppercase.

--- a/src/Locator/SanitizeLocator.php
+++ b/src/Locator/SanitizeLocator.php
@@ -56,6 +56,7 @@ class SanitizeLocator extends Locator
             'strlenMin'             => function () { return new Sanitize\StrlenMin(); },
             'titlecase'             => function () { return new Sanitize\Titlecase(); },
             'trim'                  => function () { return new Sanitize\Trim(); },
+            'uploadedFileOrNull'    => function () { return new Sanitize\UploadedFileOrNull(); },
             'uppercase'             => function () { return new Sanitize\Uppercase(); },
             'uppercaseFirst'        => function () { return new Sanitize\UppercaseFirst(); },
             'uuid'                  => function () { return new Sanitize\Uuid(); },

--- a/src/Locator/ValidateLocator.php
+++ b/src/Locator/ValidateLocator.php
@@ -64,6 +64,7 @@ class ValidateLocator extends Locator
             'titlecase'             => function () { return new Validate\Titlecase(); },
             'trim'                  => function () { return new Validate\Trim(); },
             'upload'                => function () { return new Validate\Upload(); },
+            'uploadedFile'          => function () { return new Validate\UploadedFile(); },
             'uppercase'             => function () { return new Validate\Uppercase(); },
             'uppercaseFirst'        => function () { return new Validate\UppercaseFirst(); },
             'url'                   => function () { return new Validate\Url(); },

--- a/src/Rule/Sanitize/UploadedFileOrNull.php
+++ b/src/Rule/Sanitize/UploadedFileOrNull.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\Filter\Rule\Sanitize;
+
+use Psr\Http\Message\UploadedFileInterface;
+
+/**
+ *
+ * Sets value to null if not an uploaded file
+ *
+ * @package Aura.Filter
+ *
+ */
+class UploadedFileOrNull
+{
+    /**
+     *
+     * Forces the value to null if not an uploaded file.
+     *
+     * @param object $subject The subject to be filtered.
+     *
+     * @param string $field The subject field name.
+     *
+     * @return bool True if the value was sanitized, false if not.
+     *
+     */
+    public function __invoke($subject, $field)
+    {
+        $value = $subject->$field;
+
+        if (! $value instanceof UploadedFileInterface
+            || $value->getError() !==  UPLOAD_ERR_OK
+        ) {
+            $subject->$field = null;
+        }
+
+        return true;
+    }
+}

--- a/src/Rule/Validate/UploadedFile.php
+++ b/src/Rule/Validate/UploadedFile.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\Filter\Rule\Validate;
+
+use Psr\Http\Message\UploadedFileInterface;
+
+/**
+ *
+ * Validates that the value is a PSR7 UploadedFile with various properties
+ *
+ * @package Aura.Filter
+ *
+ */
+class UploadedFile
+{
+
+    const REQUIRED       = 'required';
+    const FILE_EXTENSION = 'fileExtension';
+    const FILE_MEDIA     = 'fileMedia';
+    const SIZE_MAX       = 'sizeMax';
+    const SIZE_MIN       = 'sizeMin';
+
+    protected $rules = array(
+        self::REQUIRED,
+        self::FILE_EXTENSION,
+        self::FILE_MEDIA,
+        self::SIZE_MAX,
+        self::SIZE_MIN,
+    );
+
+
+    /**
+     *
+     * Validates the presenece and properites if a PSR7 FileUploadInterface
+     *
+     * valid options:
+     *  - required      : bool require file is uploaded
+     *  - fileExtension : array or strign of acceptable file extensions
+     *  - fileMedia     : array or strign of acceptable file media types
+     *  - sizeMax       : bytes or human readable string
+     *  - sizeMin       : bytes or human readable string
+     *
+     * @param object $subject The subject to be filtered.
+     *
+     * @param string $field The subject field name.
+     *
+     * @return bool True if valid, false if not.
+     *
+     */
+    public function __invoke($subject, $field, array $options)
+    {
+        $value = $subject->$field;
+
+        if (! $this->isRequired($options)
+            && ! $this->fileWasUploaded($value)
+        ) {
+            return true;
+        }
+
+        foreach ($this->rules as $rule) {
+            if (array_key_exists($rule, $options)) {
+                if (! $this->$rule($value, $options[$rule])) {
+                    return false;
+                }
+            }
+        }
+        // looks like we're ok!
+        return true;
+    }
+
+    /**
+     * If the file required to be uploaded?
+     *
+     * @param array $options the options passed tot the filter
+     *
+     * @return bool
+     *
+     * @access protected
+     */
+    protected function isRequired(array $options)
+    {
+        return (
+            isset($options[self::REQUIRED])
+            && $options[self::REQUIRED] == true
+        );
+    }
+
+    /**
+     * Is value an instance of a PSR7 UploadedFileInterface?
+     *
+     * @param mixed $value value being validated
+     *
+     * @return bool
+     *
+     * @access protected
+     */
+    protected function isUploadedFile($value)
+    {
+        return ($value instanceof UploadedFileInterface);
+    }
+
+    /**
+     * Was a file uploaded ?
+     *
+     * @param mixed $value value being validated
+     *
+     * @return bool
+     *
+     * @access protected
+     */
+    protected function fileWasUploaded($value)
+    {
+        if (! $this->isUploadedFile($value)) {
+            return false;
+        }
+
+        if ($value->getError() !==  UPLOAD_ERR_OK) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Required Rule Test
+     *
+     * @param mixed $value  value being validated
+     * @param bool  $option if the file is required
+     *
+     * @return bool
+     *
+     * @access protected
+     */
+    protected function required($value, $option)
+    {
+        if ($option === false) {
+            return true;
+        }
+
+        return $this->fileWasUploaded($value);
+    }
+
+    /**
+     * FileExtension Rule Test
+     *
+     * @param mixed        $value value being validated
+     * @param string|array $exts  array or string of valid extensions
+     *
+     * @return bool
+     *
+     * @access protected
+     */
+    protected function fileExtension($value, $exts)
+    {
+        $filename = $value->getClientFilename();
+        $ext = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+        return in_array($ext, array_map('strtolower', (array) $exts));
+    }
+
+    /**
+     * FileMedia Rule Test
+     *
+     * @param mixed        $value  value being validated
+     * @param string|array $medias array or string of valid media types
+     *
+     * @return bool
+     *
+     * @access protected
+     */
+    protected function fileMedia($value, $medias)
+    {
+        $media = $value->getClientMediaType();
+        return in_array($media, (array) $medias);
+    }
+
+    /**
+     * SizeMax Rule Test
+     *
+     * @param mixed $value value being validated
+     * @param mixed $max   maximum file size
+     *
+     * @return bool
+     *
+     * @access protected
+     */
+    protected function sizeMax($value, $max)
+    {
+        $size = $value->getSize();
+        return $size < $this->parseHumanSize($max);
+    }
+
+    /**
+     * SizeMin
+     *
+     * @param mixed $value value being validated
+     * @param mixed $min   minimum file size
+     *
+     * @return mixed
+     *
+     * @access protected
+     */
+    protected function sizeMin($value, $min)
+    {
+        $size = $value->getSize();
+        return $size > $this->parseHumanSize($min);
+    }
+
+    /**
+     * Parse human readable size to bytes
+     *
+     * @param mixed $size size indicator
+     *
+     * @return double|int
+     *
+     * @access public
+     */
+    public function parseHumanSize($size)
+    {
+        $number = substr($size, 0, -2);
+        switch(strtoupper(substr($size, -2))){
+        case "KB":
+            return $number * 1024;
+        case "MB":
+            return $number * pow(1024, 2);
+        case "GB":
+            return $number * pow(1024, 3);
+        case "TB":
+            return $number * pow(1024, 4);
+        case "PB":
+            return $number * pow(1024, 5);
+        default:
+            return $size;
+        }
+    }
+}

--- a/tests/Rule/Sanitize/UploadedFileOrNullTest.php
+++ b/tests/Rule/Sanitize/UploadedFileOrNullTest.php
@@ -1,0 +1,20 @@
+<?php
+namespace Aura\Filter\Rule\Sanitize;
+
+use Zend\Diactoros\UploadedFile as Psr7File;
+
+class UploadedFileOrNullTest extends AbstractSanitizeTest
+{
+
+    public function providerTo()
+    {
+        $file = new Psr7File('file', 2048, UPLOAD_ERR_OK, 'foo.bar', 'foo/bar');
+        $noFile = new Psr7File('file', 0,  UPLOAD_ERR_NO_FILE);
+
+        return array(
+            array( $file, true, $file ),
+            array( $noFile, true, null ),
+            array( 'not', true, null ),
+        );
+    }
+}

--- a/tests/Rule/Validate/UploadedFileTest.php
+++ b/tests/Rule/Validate/UploadedFileTest.php
@@ -1,0 +1,199 @@
+<?php
+namespace Aura\Filter\Rule\Validate;
+
+use Zend\Diactoros\UploadedFile as Psr7File;
+
+class UploadedFileTest extends AbstractValidateTest
+{
+    public function providerIs()
+    {
+        $file = new Psr7File('file', 2048, UPLOAD_ERR_OK, 'foo.bar', 'foo/bar');
+        $noFile = new Psr7File('file', 0,  UPLOAD_ERR_NO_FILE);
+
+        $params = array(
+            array( // uploaded, required
+                $file,
+                array(UploadedFile::REQUIRED => true)
+            ),
+            array( // uploaded, not required
+                $file,
+                array(UploadedFile::REQUIRED => false)
+            ),
+            array( // not uploaded, not required
+                $noFile,
+                array(UploadedFile::REQUIRED => false)
+            ),
+
+            // Extension
+            array( // not uploaded, not required, bad ext
+                $noFile,
+                array(
+                    UploadedFile::REQUIRED => false,
+                    UploadedFile::FILE_EXTENSION => 'baz'
+                )
+            ),
+            array( // uploaded, good ext
+                $file,
+                array(UploadedFile::FILE_EXTENSION => 'bar')
+            ),
+            array( // uploaded, good ext
+                $file,
+                array(UploadedFile::FILE_EXTENSION => ['baz', 'bar'])
+            ),
+
+            // Media
+            array( // not uploaded, not required, bad media
+                $noFile,
+                array(
+                    UploadedFile::REQUIRED => false,
+                    UploadedFile::FILE_MEDIA => 'bing/baz'
+                )
+            ),
+            array( // uploaded, good media
+                $file,
+                array(UploadedFile::FILE_MEDIA => 'foo/bar')
+            ),
+            array( // uploaded, good media
+                $file,
+                array(UploadedFile::FILE_MEDIA => ['bing/baz', 'foo/bar'])
+            ),
+
+            // Size Max
+            array( // not uploaded, not required, bad size
+                $noFile,
+                array(
+                    UploadedFile::REQUIRED => false,
+                    UploadedFile::SIZE_MAX => 1
+                )
+            ),
+            array( // uploaded, good size
+                $file,
+                array(UploadedFile::SIZE_MAX => 4096)
+            ),
+            array( // uploaded, good size
+                $file,
+                array(UploadedFile::SIZE_MAX => '3KB')
+            ),
+
+            // Size Min
+            array( // not uploaded, not required, bad size
+                $noFile,
+                array(
+                    UploadedFile::REQUIRED => false,
+                    UploadedFile::SIZE_MIN => 999999
+                )
+            ),
+            array( // uploaded, good size
+                $file,
+                array(UploadedFile::SIZE_MIN => 1024)
+            ),
+            array( // uploaded, good size
+                $file,
+                array(UploadedFile::SIZE_MIN => '1KB')
+            ),
+        );
+
+        return $params;
+    }
+
+    public function providerIsNot()
+    {
+        $file = new Psr7File('file', 2048, UPLOAD_ERR_OK, 'foo.bar', 'foo/bar');
+        $noFile = new Psr7File('file', 0,  UPLOAD_ERR_NO_FILE);
+
+        return array(
+            array( // not uploaded, required
+                $noFile,
+                array(UploadedFile::REQUIRED => true)
+            ),
+            array( // not interface, required
+                null,
+                array(UploadedFile::REQUIRED => true)
+            ),
+
+            // Extension
+            array( // uploaded, bad ext
+                $file,
+                array(UploadedFile::FILE_EXTENSION => 'baz')
+            ),
+            array( // uploaded, bad exts
+                $file,
+                array(UploadedFile::FILE_EXTENSION => ['baz', 'bing'])
+            ),
+
+            // Media
+            array( // uploaded, bad media
+                $file,
+                array(UploadedFile::FILE_MEDIA => 'bing/baz')
+            ),
+            array( // uploaded, bad medias
+                $file,
+                array(UploadedFile::FILE_MEDIA => ['bing/baz', 'boom/bang'])
+            ),
+
+            // Size Max
+            array( // uploaded, bad size
+                $file,
+                array(UploadedFile::SIZE_MAX => 1024)
+            ),
+            array( // uploaded, bad size
+                $file,
+                array(UploadedFile::SIZE_MAX => '1KB')
+            ),
+
+            // Size Min
+            array( // uploaded, bad size
+                $file,
+                array(UploadedFile::SIZE_MIN => 9999999)
+            ),
+            array( // uploaded, bad size
+                $file,
+                array(UploadedFile::SIZE_MIN => '1MB')
+            ),
+        );
+    }
+
+    protected function invoke($value, $args = null)
+    {
+        $subject = $this->getSubject($value);
+        $field = 'foo';
+        $rule = $this->newRule();
+        return call_user_func($rule, $subject, $field, $args);
+    }
+
+    /**
+     * @dataProvider providerIs
+     */
+    public function testIs($value, $args = null)
+    {
+        $this->assertTrue($this->invoke($value, $args));
+    }
+
+    /**
+     * @dataProvider providerIsNot
+     */
+    public function testIsNot($value, $args = null)
+    {
+        $this->assertFalse($this->invoke($value, $args));
+    }
+
+    public function testParseHumanSize()
+    {
+        $units = [
+            '1KB' => 1024,
+            '1MB' => pow(1024, 2),
+            '1GB' => pow(1024, 3),
+            '1TB' => pow(1024, 4),
+            '1PB' => pow(1024, 5)
+        ];
+
+        $rule = $this->newRule();
+
+        foreach ($units as $human => $machine) {
+            $this->assertEquals(
+                $machine,
+                $rule->parseHumanSize($human)
+            );
+        }
+    }
+}


### PR DESCRIPTION
See #118 for previous discussion.

Note:
- have `psr/http-message` as a regular dependency here, not suggest, as that seems right to me
- my other concerns raised in #111, included here for convenience

> It seems like the suggestion is to combine the 5 rules into a single rule
> configured by an array.  That seems a little counter intuitive to me as they
> seem to be 'different' rules, but I'm not horrified by it as the rules are
> obviously related.
> 
> My concerns would be:
> - combining somewhat disparate concerns into a single class
> - more burdensome configuration, remembering the correct keys to pass
> - terse method signature   (`__invoke($subject, $field, $options)`)
> - would not this have an impact on generating useful error messages? ie. I'm not sure you can determine _which_ part of the rule failed.
> 
> Maybe I'm off on this though.
> In regards to the slash in the name, I'm pretty sure that could easily be eliminated regardless of the combination approach, as that's just how the locator is configured, and could certainly just be something like `uploadSizeMax` or `maxUploadSize`
> 
> thoughts, feelings, concerns, rebuttals, remarks to alleviate my concerns?
