### PR TITLE
Add `useBlankField` to SanitizeSpec

### DIFF
--- a/src/Spec/SanitizeSpec.php
+++ b/src/Spec/SanitizeSpec.php
@@ -28,6 +28,15 @@ class SanitizeSpec extends Spec
 
     /**
      *
+     * If the field is blank, use value from this field as the replacement value.
+     *
+     * @param string
+     *
+     */
+    protected $blank_field;
+
+    /**
+     *
      * Applies the rule specification to a subject.
      *
      * @param mixed $subject The filter subject.
@@ -37,6 +46,13 @@ class SanitizeSpec extends Spec
      */
     public function __invoke($subject)
     {
+
+        if ($this->subjectFieldIsBlank($subject) && $this->blank_field) {
+            $field = $this->field;
+            $replace_with = $this->blank_field;
+            $subject->$field = $subject->$replace_with;
+        }
+
         if (! $this->subjectFieldIsBlank($subject)) {
             return parent::__invoke($subject);
         }
@@ -97,6 +113,21 @@ class SanitizeSpec extends Spec
     {
         $this->allow_blank = true;
         $this->blank_value = $blank_value;
+        return $this;
+    }
+
+    /**
+     *
+     * Use value from $field_name for blank field.
+     *
+     * @param string $field_name Replace the blank field with the value from field.
+     *
+     * @return self
+     *
+     */
+    public function useBlankField($field_name)
+    {
+        $this->blank_field = $field_name;
         return $this;
     }
 

--- a/tests/Spec/SanitizeSpecTest.php
+++ b/tests/Spec/SanitizeSpecTest.php
@@ -90,4 +90,12 @@ class SanitizeSpecTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->spec->__invoke($subject));
         $this->assertSame('xxx', $subject->foo);
     }
+
+    public function testToBlankOr_useBlankField()
+    {
+        $this->spec->field('foo')->toBlankOr('strlen', 3)->useBlankField('bar');
+        $subject = (object) array('bar' => 'xxxxxx');
+        $this->assertTrue($this->spec->__invoke($subject));
+        $this->assertSame('xxx', $subject->foo);
+    }
 }


### PR DESCRIPTION
RE: #119

Thoughts?

This makes `SanitizeSpec` work like this:

*First*, if field is blank and `blank_field` is set, it will set `field` to the value of `blank_field`.

It *then continues as before*. This *differs* from the usage of `blank_value`, which is simply used as a default value and incurs no further processing. In my use cases, when I want to "sanitize a field to the value of another field" I usually want to *start* with that value, and then transform it (eg. creating a default "slug" from a "title" property)

Here, setting `blank_field` does *not* set `allow_blank`. If `blank_field` is *also* blank, and `field` does not `allow_blank`, it will still fail, and if `blank_value` is set, it will use that in the end.
