### PR TITLE
Add type declaration . Thank you rector.

### DIFF
--- a/src/AbstractStaticFilter.php
+++ b/src/AbstractStaticFilter.php
@@ -68,7 +68,7 @@ abstract class AbstractStaticFilter
      * @return bool True on success, false on failure.
      *
      */
-    public static function validate($value, $rule)
+    public static function validate($value, string $rule): bool
     {
         if (! static::$instance) {
             $class = get_called_class();
@@ -95,7 +95,7 @@ abstract class AbstractStaticFilter
      * @return bool True on success, false on failure.
      *
      */
-    public static function sanitize(&$value, $rule)
+    public static function sanitize(&$value, string $rule): bool
     {
         if (! static::$instance) {
             $class = get_called_class();

--- a/src/Exception/FilterFailed.php
+++ b/src/Exception/FilterFailed.php
@@ -56,7 +56,7 @@ class FilterFailed extends Exception
      * @return null
      *
      */
-    public function setFilterClass($filter_class)
+    public function setFilterClass(string $filter_class): void
     {
         $this->filter_class = $filter_class;
     }
@@ -65,10 +65,9 @@ class FilterFailed extends Exception
      *
      * Gets the class of the filter being applied.
      *
-     * @return string
      *
      */
-    public function getFilterClass()
+    public function getFilterClass(): string
     {
         return $this->filter_class;
     }
@@ -82,7 +81,7 @@ class FilterFailed extends Exception
      * @return null
      *
      */
-    public function setFailures(FailureCollection $failures)
+    public function setFailures(FailureCollection $failures): void
     {
         $this->failures = $failures;
     }
@@ -91,10 +90,9 @@ class FilterFailed extends Exception
      *
      * Gets the failures from the filter.
      *
-     * @return FailureCollection
      *
      */
-    public function getFailures()
+    public function getFailures(): FailureCollection
     {
         return $this->failures;
     }
@@ -108,7 +106,7 @@ class FilterFailed extends Exception
      * @return null
      *
      */
-    public function setSubject($subject)
+    public function setSubject($subject): void
     {
         $this->subject = $subject;
     }

--- a/src/Failure/Failure.php
+++ b/src/Failure/Failure.php
@@ -73,10 +73,9 @@ class Failure implements JsonSerializable
      *
      * Returns the field that failed.
      *
-     * @return string
      *
      */
-    public function getField()
+    public function getField(): string
     {
         return $this->field;
     }
@@ -85,10 +84,9 @@ class Failure implements JsonSerializable
      *
      * Returns the failure message.
      *
-     * @return string
      *
      */
-    public function getMessage()
+    public function getMessage(): string
     {
         return $this->message;
     }
@@ -97,22 +95,22 @@ class Failure implements JsonSerializable
      *
      * Returns the arguments passed to the rule specification.
      *
-     * @return array
      *
+     * @return mixed[]
      */
-    public function getArgs()
+    public function getArgs(): array
     {
         return $this->args;
     }
 
    /**
-    *
-    * Returns an array for json_encode.
-    *
-    * @return array
-    *
-    */
-    public function jsonSerialize(): mixed
+     *
+     * Returns an array for json_encode.
+     *
+     *
+     * @return array<string, mixed[]>
+     */
+    public function jsonSerialize(): array
     {
         return array(
             'field' => $this->field,

--- a/src/Failure/Failure.php
+++ b/src/Failure/Failure.php
@@ -112,7 +112,7 @@ class Failure implements JsonSerializable
     * @return array
     *
     */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array(
             'field' => $this->field,

--- a/src/Failure/FailureCollection.php
+++ b/src/Failure/FailureCollection.php
@@ -35,10 +35,9 @@ class FailureCollection extends ArrayObject
      *
      * Is the failure collection empty?
      *
-     * @return bool
      *
      */
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         return count($this) === 0;
     }
@@ -53,10 +52,9 @@ class FailureCollection extends ArrayObject
      *
      * @param array $args The arguments passed to the rule specification.
      *
-     * @return Failure
      *
      */
-    public function set($field, $message, array $args = array())
+    public function set(string $field, string $message, array $args = array()): Failure
     {
         $failure = $this->newFailure($field, $message, $args);
         $this[$field] = array($failure);
@@ -73,10 +71,9 @@ class FailureCollection extends ArrayObject
      *
      * @param array $args The arguments passed to the rule specification.
      *
-     * @return Failure
      *
      */
-    public function add($field, $message, array $args = array())
+    public function add(string $field, string $message, array $args = array()): Failure
     {
         $failure = $this->newFailure($field, $message, $args);
         $this[$field][] = $failure;
@@ -93,10 +90,9 @@ class FailureCollection extends ArrayObject
      *
      * @param array $args The arguments passed to the rule specification.
      *
-     * @return Failure
      *
      */
-    protected function newFailure($field, $message, array $args = array())
+    protected function newFailure(string $field, string $message, array $args = array()): Failure
     {
         return new Failure($field, $message, $args);
     }
@@ -107,10 +103,10 @@ class FailureCollection extends ArrayObject
      *
      * @param string $field The field name.
      *
-     * @return array
      *
+     * @return mixed[]
      */
-    public function forField($field)
+    public function forField(string $field): array
     {
         if (! isset($this[$field])) {
             return array();
@@ -123,10 +119,10 @@ class FailureCollection extends ArrayObject
      *
      * Returns all failure messages for all fields.
      *
-     * @return array
      *
+     * @return mixed[][]
      */
-    public function getMessages()
+    public function getMessages(): array
     {
         $messages = array();
         foreach ($this as $field => $failures) {
@@ -141,10 +137,10 @@ class FailureCollection extends ArrayObject
      *
      * @param string $field The field name.
      *
-     * @return array
      *
+     * @return mixed[]
      */
-    public function getMessagesForField($field)
+    public function getMessagesForField(string $field): array
     {
         if (! isset($this[$field])) {
             return array();
@@ -163,10 +159,9 @@ class FailureCollection extends ArrayObject
      *
      * @param string $prefix Prefix each line with this string.
      *
-     * @return string
      *
      */
-    public function getMessagesAsString($prefix = '')
+    public function getMessagesAsString(string $prefix = ''): string
     {
         $string = '';
         foreach ($this as $field => $failures) {
@@ -186,10 +181,9 @@ class FailureCollection extends ArrayObject
      *
      * @param string $prefix Prefix each line with this string.
      *
-     * @return string
      *
      */
-    public function getMessagesForFieldAsString($field, $prefix = '')
+    public function getMessagesForFieldAsString(string $field, string $prefix = ''): string
     {
         $string = '';
         foreach ($this->forField($field) as $failure) {

--- a/src/FilterFactory.php
+++ b/src/FilterFactory.php
@@ -64,10 +64,9 @@ class FilterFactory
      *
      * @param string $class The filter class to instantiate.
      *
-     * @return SubjectFilter
      *
      */
-    public function newSubjectFilter($class = 'Aura\Filter\SubjectFilter')
+    public function newSubjectFilter(string $class = 'Aura\Filter\SubjectFilter'): object
     {
         return new $class(
             $this->newValidateSpec(),
@@ -81,10 +80,9 @@ class FilterFactory
      *
      * Returns a new ValueFilter instance.
      *
-     * @return ValueFilter
      *
      */
-    public function newValueFilter()
+    public function newValueFilter(): ValueFilter
     {
         return new ValueFilter(
             $this->newValidateLocator(),
@@ -96,10 +94,9 @@ class FilterFactory
      *
      * Returns a new ValidateSpec instance.
      *
-     * @return ValidateSpec
      *
      */
-    public function newValidateSpec()
+    public function newValidateSpec(): ValidateSpec
     {
         return new ValidateSpec($this->newValidateLocator());
     }
@@ -108,10 +105,9 @@ class FilterFactory
      *
      * Returns a new SanitizeSpec instance.
      *
-     * @return SanitizeSpec
      *
      */
-    public function newSanitizeSpec()
+    public function newSanitizeSpec(): SanitizeSpec
     {
         return new SanitizeSpec($this->newSanitizeLocator());
     }
@@ -120,10 +116,9 @@ class FilterFactory
      *
      * Returns a new SubSpecFactory instance.
      *
-     * @return SubSpecFactory
      *
      */
-    public function newSubSpecFactory()
+    public function newSubSpecFactory(): SubSpecFactory
     {
         return new SubSpecFactory($this);
     }
@@ -132,10 +127,9 @@ class FilterFactory
      *
      * Returns a new ValidateLocator instance.
      *
-     * @return ValidateLocator
      *
      */
-    public function newValidateLocator()
+    public function newValidateLocator(): ValidateLocator
     {
         return new ValidateLocator($this->validate_factories);
     }
@@ -144,10 +138,9 @@ class FilterFactory
      *
      * Returns a new SanitizeLocator instance.
      *
-     * @return SanitizeLocator
      *
      */
-    public function newSanitizeLocator()
+    public function newSanitizeLocator(): SanitizeLocator
     {
         return new SanitizeLocator($this->sanitize_factories);
     }
@@ -156,10 +149,9 @@ class FilterFactory
      *
      * Returns a new FailureCollection instance.
      *
-     * @return FailureCollection
      *
      */
-    public function newFailureCollection()
+    public function newFailureCollection(): FailureCollection
     {
         return new FailureCollection();
     }

--- a/src/FilterFactory.php
+++ b/src/FilterFactory.php
@@ -66,7 +66,7 @@ class FilterFactory
      *
      *
      */
-    public function newSubjectFilter(string $class = 'Aura\Filter\SubjectFilter'): object
+    public function newSubjectFilter(string $class = SubjectFilter::class): object
     {
         return new $class(
             $this->newValidateSpec(),

--- a/src/Locator/Locator.php
+++ b/src/Locator/Locator.php
@@ -8,6 +8,7 @@
  */
 namespace Aura\Filter\Locator;
 
+use Aura\Filter\Exception\RuleNotMapped;
 use Aura\Filter\Exception;
 
 /**
@@ -60,7 +61,7 @@ class Locator
      * @return null
      *
      */
-    protected function initFactories(array $factories)
+    protected function initFactories(array $factories): void
     {
         foreach ($factories as $name => $spec) {
             $this->set($name, $spec);
@@ -78,7 +79,7 @@ class Locator
      * @return void
      *
      */
-    public function set($name, $spec)
+    public function set(string $name, callable $spec): void
     {
         $this->factories[$name] = $spec;
         unset($this->instances[$name]);
@@ -95,13 +96,13 @@ class Locator
      * @throws Exception\RuleNotMapped
      *
      */
-    public function get($name)
+    public function get(string $name)
     {
         $mapped = isset($this->factories[$name])
                || isset($this->instances[$name]);
 
         if (! $mapped) {
-            throw new Exception\RuleNotMapped($name);
+            throw new RuleNotMapped($name);
         }
 
         if (! isset($this->instances[$name])) {

--- a/src/Locator/SanitizeLocator.php
+++ b/src/Locator/SanitizeLocator.php
@@ -29,7 +29,7 @@ class SanitizeLocator extends Locator
      * @return null
      *
      */
-    protected function initFactories(array $factories)
+    protected function initFactories(array $factories): void
     {
         $this->factories = array(
             'alnum'                 => function () { return new Sanitize\Alnum(); },

--- a/src/Locator/ValidateLocator.php
+++ b/src/Locator/ValidateLocator.php
@@ -29,7 +29,7 @@ class ValidateLocator extends Locator
      * @return null
      *
      */
-    protected function initFactories(array $factories)
+    protected function initFactories(array $factories): void
     {
         $this->factories = array(
             'alnum'                 => function () { return new Validate\Alnum(); },

--- a/src/Rule/AbstractBoolean.php
+++ b/src/Rule/AbstractBoolean.php
@@ -41,10 +41,9 @@ abstract class AbstractBoolean
      *
      * @param mixed $value The value to check.
      *
-     * @return bool
      *
      */
-    protected function isTrue($value)
+    protected function isTrue($value): bool
     {
         if (! $this->isBoolIsh($value)) {
             return false;
@@ -59,10 +58,9 @@ abstract class AbstractBoolean
      *
      * @param mixed $value The value to check.
      *
-     * @return bool
      *
      */
-    protected function isFalse($value)
+    protected function isFalse($value): bool
     {
         if (! $this->isBoolIsh($value)) {
             return false;
@@ -77,10 +75,9 @@ abstract class AbstractBoolean
      *
      * @param mixed $value The value to check.
      *
-     * @return bool
      *
      */
-    protected function isBoolIsh($value)
+    protected function isBoolIsh($value): bool
     {
         if (is_string($value) || is_int($value) || is_bool($value)) {
             return true;

--- a/src/Rule/AbstractCharCase.php
+++ b/src/Rule/AbstractCharCase.php
@@ -84,10 +84,9 @@ abstract class AbstractCharCase extends AbstractStrlen
      *
      * @param string $str String to convert case.
      *
-     * @return int
      *
      */
-    protected function ucfirst(string $str)
+    protected function ucfirst(string $str): string
     {
         $len = $this->strlen($str);
         if ($len == 0) {
@@ -108,10 +107,9 @@ abstract class AbstractCharCase extends AbstractStrlen
      *
      * @param string $str String to convert case.
      *
-     * @return int
      *
      */
-    protected function lcfirst(string $str)
+    protected function lcfirst(string $str): string
     {
         $len = $this->strlen($str);
         if ($len == 0) {

--- a/src/Rule/AbstractCharCase.php
+++ b/src/Rule/AbstractCharCase.php
@@ -30,7 +30,7 @@ abstract class AbstractCharCase extends AbstractStrlen
      * @return string
      *
      */
-    protected function strtolower($str)
+    protected function strtolower(string $str): string
     {
         if ($this->mbstring()) {
             return mb_convert_case($str, MB_CASE_LOWER, 'UTF-8');
@@ -49,7 +49,7 @@ abstract class AbstractCharCase extends AbstractStrlen
      * @return string
      *
      */
-    protected function strtoupper($str)
+    protected function strtoupper(string $str): string
     {
         if ($this->mbstring()) {
             return mb_convert_case($str, MB_CASE_UPPER, 'UTF-8');
@@ -68,7 +68,7 @@ abstract class AbstractCharCase extends AbstractStrlen
      * @return int
      *
      */
-    protected function ucwords($str)
+    protected function ucwords(string $str): string
     {
         if ($this->mbstring()) {
             return mb_convert_case($str, MB_CASE_TITLE, 'UTF-8');
@@ -87,7 +87,7 @@ abstract class AbstractCharCase extends AbstractStrlen
      * @return int
      *
      */
-    protected function ucfirst($str)
+    protected function ucfirst(string $str)
     {
         $len = $this->strlen($str);
         if ($len == 0) {
@@ -111,7 +111,7 @@ abstract class AbstractCharCase extends AbstractStrlen
      * @return int
      *
      */
-    protected function lcfirst($str)
+    protected function lcfirst(string $str)
     {
         $len = $this->strlen($str);
         if ($len == 0) {

--- a/src/Rule/AbstractCharCase.php
+++ b/src/Rule/AbstractCharCase.php
@@ -65,7 +65,6 @@ abstract class AbstractCharCase extends AbstractStrlen
      *
      * @param string $str String to convert case.
      *
-     * @return int
      *
      */
     protected function ucwords(string $str): string

--- a/src/Rule/AbstractStrlen.php
+++ b/src/Rule/AbstractStrlen.php
@@ -8,6 +8,7 @@
  */
 namespace Aura\Filter\Rule;
 
+use Aura\Filter\Exception\MalformedUtf8;
 use Aura\Filter\Exception;
 
 /**
@@ -27,7 +28,7 @@ abstract class AbstractStrlen
      * @return bool
      *
      */
-    protected function mbstring()
+    protected function mbstring(): bool
     {
         return extension_loaded('mbstring');
     }
@@ -39,7 +40,7 @@ abstract class AbstractStrlen
      * @return bool
      *
      */
-    protected function iconv()
+    protected function iconv(): bool
     {
         return extension_loaded('iconv');
     }
@@ -54,7 +55,7 @@ abstract class AbstractStrlen
      * @return int
      *
      */
-    protected function strlen($str)
+    protected function strlen(string $str): int
     {
         if ($this->iconv()) {
             return $this->strlenIconv($str);
@@ -82,7 +83,7 @@ abstract class AbstractStrlen
      * @throws Exception\MalformedUtf8
      *
      */
-    protected function substrIconv($str,$start,$length)
+    protected function substrIconv(string $str,int $start,int $length)
     {
         $level = error_reporting(0);
         $substr = iconv_substr($str,$start,$length, 'UTF-8');
@@ -92,9 +93,9 @@ abstract class AbstractStrlen
             return $substr;
         }
 
-        throw new Exception\MalformedUtf8();
+        throw new MalformedUtf8();
     }
-    
+
     /**
      *
      * Wrapper for `iconv_strlen()` to throw an exception on malformed UTF-8.
@@ -106,7 +107,7 @@ abstract class AbstractStrlen
      * @throws Exception\MalformedUtf8
      *
      */
-    protected function strlenIconv($str)
+    protected function strlenIconv(string $str)
     {
         $level = error_reporting(0);
         $strlen = iconv_strlen($str, 'UTF-8');
@@ -116,7 +117,7 @@ abstract class AbstractStrlen
             return $strlen;
         }
 
-        throw new Exception\MalformedUtf8();
+        throw new MalformedUtf8();
     }
 
     /**
@@ -133,7 +134,7 @@ abstract class AbstractStrlen
      * @return string
      *
      */
-    protected function substr($str, $start, $length = null)
+    protected function substr(string $str, int $start, $length = null): string
     {
         if ($this->iconv()) {
             return $this->substrIconv($str, $start, $length);
@@ -167,7 +168,7 @@ abstract class AbstractStrlen
      * @return string
      *
      */
-    protected function strpad($input, $pad_length, $pad_str = ' ', $pad_type = STR_PAD_RIGHT)
+    protected function strpad(string $input, int $pad_length, string $pad_str = ' ', int $pad_type = STR_PAD_RIGHT)
     {
         $input_len = $this->strlen($input);
         if ($pad_length <= $input_len) {

--- a/src/Rule/AbstractUuid.php
+++ b/src/Rule/AbstractUuid.php
@@ -23,10 +23,9 @@ abstract class AbstractUuid
      *
      * @param string $value The value to be checked.
      *
-     * @return bool
      *
      */
-    protected function isCanonical(string $value)
+    protected function isCanonical(string $value): bool
     {
         $regex = '/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i';
         return (bool) preg_match($regex, $value);
@@ -38,10 +37,9 @@ abstract class AbstractUuid
      *
      * @param string $value The value to be checked.
      *
-     * @return bool
      *
      */
-    protected function isHexOnly(string $value)
+    protected function isHexOnly(string $value): bool
     {
         $regex = '/^[a-f0-9]{32}$/i';
         return (bool) preg_match($regex, $value);

--- a/src/Rule/AbstractUuid.php
+++ b/src/Rule/AbstractUuid.php
@@ -26,7 +26,7 @@ abstract class AbstractUuid
      * @return bool
      *
      */
-    protected function isCanonical($value)
+    protected function isCanonical(string $value)
     {
         $regex = '/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i';
         return (bool) preg_match($regex, $value);
@@ -41,7 +41,7 @@ abstract class AbstractUuid
      * @return bool
      *
      */
-    protected function isHexOnly($value)
+    protected function isHexOnly(string $value)
     {
         $regex = '/^[a-f0-9]{32}$/i';
         return (bool) preg_match($regex, $value);

--- a/src/Rule/Validate/Email.php
+++ b/src/Rule/Validate/Email.php
@@ -383,10 +383,9 @@ class Email
      *
      * Is the intl extension loaded?
      *
-     * @return bool
      *
      */
-    protected function intl()
+    protected function intl(): bool
     {
         return extension_loaded('intl');
     }
@@ -400,7 +399,7 @@ class Email
      * @return string The email with the IDN converted to ASCII (if possible).
      *
      */
-    protected function idnToAscii($email)
+    protected function idnToAscii(string $email): string
     {
         $parts = explode('@', $email);
         $domain = array_pop($parts);
@@ -434,7 +433,7 @@ class Email
      * $errorlevel = false and $errorlevel = 0.
      *
      */
-    protected function isEmail($email, $checkDns = false, $errorlevel = false)
+    protected function isEmail(string $email, bool $checkDns = false, $errorlevel = false)
     {
         $this->reset($email, $checkDns, $errorlevel);
         $this->parse();
@@ -460,7 +459,7 @@ class Email
      * @return null
      *
      */
-    protected function reset($email, $checkDns, $errorlevel)
+    protected function reset(string $email, bool $checkDns, $errorlevel): void
     {
         $this->email = $email;
 
@@ -523,7 +522,7 @@ class Email
      * @return null
      *
      */
-    protected function setThresholdDiagnose($errorlevel)
+    protected function setThresholdDiagnose($errorlevel): void
     {
         if (is_bool($errorlevel)) {
             $this->threshold = Email::VALID;
@@ -554,7 +553,7 @@ class Email
      * @return null
      *
      */
-    protected function parse()
+    protected function parse(): void
     {
         for ($this->pos = 0; $this->pos < $this->rawLength; $this->pos++) {
             $this->token = $this->email[$this->pos];
@@ -574,7 +573,7 @@ class Email
      * @return null
      *
      */
-    protected function parseContext()
+    protected function parseContext(): void
     {
         switch ($this->context) {
             case Email::COMPONENT_LOCALPART:
@@ -610,7 +609,7 @@ class Email
      * @return null
      *
      */
-    protected function parseComponentLocalPart()
+    protected function parseComponentLocalPart(): void
     {
         // http://tools.ietf.org/html/rfc5322#section-3.4.1
         //   local-part = dot-atom / quoted-string / obs-local-part
@@ -809,7 +808,7 @@ class Email
      * @return null
      *
      */
-    protected function parseComponentDomain()
+    protected function parseComponentDomain(): void
     {
         // http://tools.ietf.org/html/rfc5322#section-3.4.1
         //   domain = dot-atom / domain-literal / obs-domain
@@ -1020,7 +1019,7 @@ class Email
      * @return null
      *
      */
-    protected function parseComponentLiteral()
+    protected function parseComponentLiteral(): void
     {
         // http://tools.ietf.org/html/rfc5322#section-3.4.1
         //   domain-literal = [CFWS] "[" *([FWS] dtext) [FWS] "]" [CFWS]
@@ -1222,7 +1221,7 @@ class Email
      * @return null
      *
      */
-    protected function parseContextQuotedString()
+    protected function parseContextQuotedString(): void
     {
         // http://tools.ietf.org/html/rfc5322#section-3.2.4
         //   quoted-string = [CFWS]
@@ -1322,7 +1321,7 @@ class Email
      * @return null
      *
      */
-    protected function parseContextQuotedPair()
+    protected function parseContextQuotedPair(): void
     {
         // http://tools.ietf.org/html/rfc5322#section-3.2.1
         //   quoted-pair = ("\" (VCHAR / WSP)) / obs-qp
@@ -1389,7 +1388,7 @@ class Email
      * @return null
      *
      */
-    protected function parseContextComment()
+    protected function parseContextComment(): void
     {
         // http://tools.ietf.org/html/rfc5322#section-3.2.2
         //   comment = "(" *([FWS] ccontent) [FWS] ")"
@@ -1483,7 +1482,7 @@ class Email
      * @return null
      *
      */
-    protected function parseContextFws()
+    protected function parseContextFws(): void
     {
         // http://tools.ietf.org/html/rfc5322#section-3.2.2
         //   FWS = ([*WSP CRLF] 1*WSP) /  obs-FWS
@@ -1569,7 +1568,7 @@ class Email
      * @return null
      *
      */
-    protected function parseFinal()
+    protected function parseFinal(): void
     {
         // Some simple final tests
         if ((int) max($this->returnStatus) < Email::RFC5322) {
@@ -1636,7 +1635,7 @@ class Email
      * @return null
      *
      */
-    protected function checkDns()
+    protected function checkDns(): void
     {
         // Check DNS?
         if ($this->checkDns && ((int) max($this->returnStatus) < Email::DNSWARN) && function_exists('dns_get_record')) {
@@ -1690,7 +1689,7 @@ class Email
      * @return null
      *
      */
-    protected function checkTld()
+    protected function checkTld(): void
     {
         // Check for TLD addresses
         // -----------------------
@@ -1742,7 +1741,7 @@ class Email
      * @return null
      *
      */
-    protected function finalStatus()
+    protected function finalStatus(): void
     {
         $this->returnStatus = array_unique($this->returnStatus);
         $this->finalStatus = (int) max($this->returnStatus);

--- a/src/Rule/Validate/Email.php
+++ b/src/Rule/Validate/Email.php
@@ -66,110 +66,110 @@ class Email
     /*:diagnostic constants start:*/
 
     // Categories
-    public const VALID_CATEGORY = 1;
-    public const DNSWARN = 7;
-    public const RFC5321 = 15;
-    public const CFWS = 31;
-    public const DEPREC = 63;
-    public const RFC5322 = 127;
-    public const ERR = 255;
+    protected const VALID_CATEGORY = 1;
+    protected const DNSWARN = 7;
+    protected const RFC5321 = 15;
+    protected const CFWS = 31;
+    protected const DEPREC = 63;
+    protected const RFC5322 = 127;
+    protected const ERR = 255;
 
     // Diagnoses
     // Address is valid
-    public const VALID = 0;
+    protected const VALID = 0;
     // Address is valid but a DNS check was not successful
-    public const DNSWARN_NO_MX_RECORD = 5;
-    public const DNSWARN_NO_RECORD = 6;
+    protected const DNSWARN_NO_MX_RECORD = 5;
+    protected const DNSWARN_NO_RECORD = 6;
     // Address is valid for SMTP but has unusual elements
-    public const RFC5321_TLD = 9;
-    public const RFC5321_TLDNUMERIC = 10;
-    public const RFC5321_QUOTEDSTRING = 11;
-    public const RFC5321_ADDRESSLITERAL = 12;
-    public const RFC5321_IPV6DEPRECATED = 13;
+    protected const RFC5321_TLD = 9;
+    protected const RFC5321_TLDNUMERIC = 10;
+    protected const RFC5321_QUOTEDSTRING = 11;
+    protected const RFC5321_ADDRESSLITERAL = 12;
+    protected const RFC5321_IPV6DEPRECATED = 13;
     // Address is valid within the message but cannot be used unmodified for the envelope
-    public const CFWS_COMMENT = 17;
-    public const CFWS_FWS = 18;
+    protected const CFWS_COMMENT = 17;
+    protected const CFWS_FWS = 18;
     // Address contains deprecated elements but may still be valid in restricted contexts
-    public const DEPREC_LOCALPART = 33;
-    public const DEPREC_FWS = 34;
-    public const DEPREC_QTEXT = 35;
-    public const DEPREC_QP = 36;
-    public const DEPREC_COMMENT = 37;
-    public const DEPREC_CTEXT = 38;
-    public const DEPREC_CFWS_NEAR_AT = 49;
+    protected const DEPREC_LOCALPART = 33;
+    protected const DEPREC_FWS = 34;
+    protected const DEPREC_QTEXT = 35;
+    protected const DEPREC_QP = 36;
+    protected const DEPREC_COMMENT = 37;
+    protected const DEPREC_CTEXT = 38;
+    protected const DEPREC_CFWS_NEAR_AT = 49;
     // The address is only valid according to the broad definition of RFC 5322.
     // It is otherwise invalid.
-    public const RFC5322_DOMAIN = 65;
-    public const RFC5322_TOOLONG = 66;
-    public const RFC5322_LOCAL_TOOLONG = 67;
-    public const RFC5322_DOMAIN_TOOLONG = 68;
-    public const RFC5322_LABEL_TOOLONG = 69;
-    public const RFC5322_DOMAINLITERAL = 70;
-    public const RFC5322_DOMLIT_OBSDTEXT = 71;
-    public const RFC5322_IPV6_GRPCOUNT = 72;
-    public const RFC5322_IPV6_2X2XCOLON = 73;
-    public const RFC5322_IPV6_BADCHAR = 74;
-    public const RFC5322_IPV6_MAXGRPS = 75;
-    public const RFC5322_IPV6_COLONSTRT = 76;
-    public const RFC5322_IPV6_COLONEND = 77;
+    protected const RFC5322_DOMAIN = 65;
+    protected const RFC5322_TOOLONG = 66;
+    protected const RFC5322_LOCAL_TOOLONG = 67;
+    protected const RFC5322_DOMAIN_TOOLONG = 68;
+    protected const RFC5322_LABEL_TOOLONG = 69;
+    protected const RFC5322_DOMAINLITERAL = 70;
+    protected const RFC5322_DOMLIT_OBSDTEXT = 71;
+    protected const RFC5322_IPV6_GRPCOUNT = 72;
+    protected const RFC5322_IPV6_2X2XCOLON = 73;
+    protected const RFC5322_IPV6_BADCHAR = 74;
+    protected const RFC5322_IPV6_MAXGRPS = 75;
+    protected const RFC5322_IPV6_COLONSTRT = 76;
+    protected const RFC5322_IPV6_COLONEND = 77;
     // Address is invalid for any purpose
-    public const ERR_EXPECTING_DTEXT = 129;
-    public const ERR_NOLOCALPART = 130;
-    public const ERR_NODOMAIN = 131;
-    public const ERR_CONSECUTIVEDOTS = 132;
-    public const ERR_ATEXT_AFTER_CFWS = 133;
-    public const ERR_ATEXT_AFTER_QS = 134;
-    public const ERR_ATEXT_AFTER_DOMLIT = 135;
-    public const ERR_EXPECTING_QPAIR = 136;
-    public const ERR_EXPECTING_ATEXT = 137;
-    public const ERR_EXPECTING_QTEXT = 138;
-    public const ERR_EXPECTING_CTEXT = 139;
-    public const ERR_BACKSLASHEND = 140;
-    public const ERR_DOT_START = 141;
-    public const ERR_DOT_END = 142;
-    public const ERR_DOMAINHYPHENSTART = 143;
-    public const ERR_DOMAINHYPHENEND = 144;
-    public const ERR_UNCLOSEDQUOTEDSTR = 145;
-    public const ERR_UNCLOSEDCOMMENT = 146;
-    public const ERR_UNCLOSEDDOMLIT = 147;
-    public const ERR_FWS_CRLF_X2 = 148;
-    public const ERR_FWS_CRLF_END = 149;
-    public const ERR_CR_NO_LF = 150;
+    protected const ERR_EXPECTING_DTEXT = 129;
+    protected const ERR_NOLOCALPART = 130;
+    protected const ERR_NODOMAIN = 131;
+    protected const ERR_CONSECUTIVEDOTS = 132;
+    protected const ERR_ATEXT_AFTER_CFWS = 133;
+    protected const ERR_ATEXT_AFTER_QS = 134;
+    protected const ERR_ATEXT_AFTER_DOMLIT = 135;
+    protected const ERR_EXPECTING_QPAIR = 136;
+    protected const ERR_EXPECTING_ATEXT = 137;
+    protected const ERR_EXPECTING_QTEXT = 138;
+    protected const ERR_EXPECTING_CTEXT = 139;
+    protected const ERR_BACKSLASHEND = 140;
+    protected const ERR_DOT_START = 141;
+    protected const ERR_DOT_END = 142;
+    protected const ERR_DOMAINHYPHENSTART = 143;
+    protected const ERR_DOMAINHYPHENEND = 144;
+    protected const ERR_UNCLOSEDQUOTEDSTR = 145;
+    protected const ERR_UNCLOSEDCOMMENT = 146;
+    protected const ERR_UNCLOSEDDOMLIT = 147;
+    protected const ERR_FWS_CRLF_X2 = 148;
+    protected const ERR_FWS_CRLF_END = 149;
+    protected const ERR_CR_NO_LF = 150;
     /*:diagnostic constants end:*/
 
     // function control
-    public const THRESHOLD = 16;
+    protected const THRESHOLD = 16;
 
     // Email parts
-    public const COMPONENT_LOCALPART = 0;
-    public const COMPONENT_DOMAIN = 1;
-    public const COMPONENT_LITERAL = 2;
-    public const CONTEXT_COMMENT = 3;
-    public const CONTEXT_FWS = 4;
-    public const CONTEXT_QUOTEDSTRING = 5;
-    public const CONTEXT_QUOTEDPAIR = 6;
+    protected const COMPONENT_LOCALPART = 0;
+    protected const COMPONENT_DOMAIN = 1;
+    protected const COMPONENT_LITERAL = 2;
+    protected const CONTEXT_COMMENT = 3;
+    protected const CONTEXT_FWS = 4;
+    protected const CONTEXT_QUOTEDSTRING = 5;
+    protected const CONTEXT_QUOTEDPAIR = 6;
 
     // Miscellaneous string constants
-    public const STRING_AT = '@';
-    public const STRING_BACKSLASH = '\\';
-    public const STRING_DOT = '.';
-    public const STRING_DQUOTE = '"';
-    public const STRING_OPENPARENTHESIS = '(';
-    public const STRING_CLOSEPARENTHESIS = ')';
-    public const STRING_OPENSQBRACKET = '[';
-    public const STRING_CLOSESQBRACKET = ']';
-    public const STRING_HYPHEN = '-';
-    public const STRING_COLON = ':';
-    public const STRING_DOUBLECOLON = '::';
-    public const STRING_SP = ' ';
-    public const STRING_HTAB = "\t";
-    public const STRING_CR = "\r";
-    public const STRING_LF = "\n";
-    public const STRING_IPV6TAG = 'IPv6:';
+    protected const STRING_AT = '@';
+    protected const STRING_BACKSLASH = '\\';
+    protected const STRING_DOT = '.';
+    protected const STRING_DQUOTE = '"';
+    protected const STRING_OPENPARENTHESIS = '(';
+    protected const STRING_CLOSEPARENTHESIS = ')';
+    protected const STRING_OPENSQBRACKET = '[';
+    protected const STRING_CLOSESQBRACKET = ']';
+    protected const STRING_HYPHEN = '-';
+    protected const STRING_COLON = ':';
+    protected const STRING_DOUBLECOLON = '::';
+    protected const STRING_SP = ' ';
+    protected const STRING_HTAB = "\t";
+    protected const STRING_CR = "\r";
+    protected const STRING_LF = "\n";
+    protected const STRING_IPV6TAG = 'IPv6:';
 
     // US-ASCII visible characters not valid for atext
     // <http://tools.ietf.org/html/rfc5322#section-3.2.3>
-    public const STRING_SPECIALS = '()<>[]:;@\\,."';
+    protected const STRING_SPECIALS = '()<>[]:;@\\,."';
 
     /**
      *
@@ -1143,7 +1143,7 @@ class Email
                         } elseif ((substr($IPv6, -1) === Email::STRING_COLON) && (substr($IPv6, -2, 1) !== Email::STRING_COLON)) {
                             // Address ends with a single colon
                             $this->returnStatus[] = Email::RFC5322_IPV6_COLONEND;
-                        } elseif ((is_array(preg_grep('/^[0-9A-Fa-f]{0,4}$/', $matchesIP, PREG_GREP_INVERT)) || preg_grep('/^[0-9A-Fa-f]{0,4}$/', $matchesIP, PREG_GREP_INVERT) instanceof Countable ? count(preg_grep('/^[0-9A-Fa-f]{0,4}$/', $matchesIP, PREG_GREP_INVERT)) : 0) !== 0) {
+                        } elseif (is_array(preg_grep('/^[0-9A-Fa-f]{0,4}$/', $matchesIP, PREG_GREP_INVERT)) && count(preg_grep('/^[0-9A-Fa-f]{0,4}$/', $matchesIP, PREG_GREP_INVERT)) !== 0) {
                             // Check for unmatched characters
                             $this->returnStatus[] = Email::RFC5322_IPV6_BADCHAR;
                         } else {
@@ -1672,7 +1672,7 @@ class Email
                     // MX-record for domain can't be found
                     $this->returnStatus[] = Email::DNSWARN_NO_MX_RECORD;
                     $result = @dns_get_record($this->parseData[Email::COMPONENT_DOMAIN], DNS_A + DNS_CNAME);
-                    if ((is_array($result) || $result instanceof Countable ? count($result) : 0) === 0) {
+                    if (is_array($result) && count($result) === 0) {
                         // No usable records for the domain can be found
                         $this->returnStatus[] = Email::DNSWARN_NO_RECORD;
                     }

--- a/src/Rule/Validate/Email.php
+++ b/src/Rule/Validate/Email.php
@@ -410,7 +410,7 @@ class Email
         }
 
         // put the parts back together, with the domain part converted to ascii
-        return implode('@', $parts) . '@' . idn_to_ascii($domain);
+        return implode('@', $parts) . '@' . idn_to_ascii($domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
     }
 
     /**

--- a/src/Rule/Validate/Email.php
+++ b/src/Rule/Validate/Email.php
@@ -8,6 +8,7 @@
  */
 namespace Aura\Filter\Rule\Validate;
 
+use Countable;
 use Aura\Filter\Exception;
 
 /**
@@ -65,110 +66,110 @@ class Email
     /*:diagnostic constants start:*/
 
     // Categories
-    const VALID_CATEGORY = 1;
-    const DNSWARN = 7;
-    const RFC5321 = 15;
-    const CFWS = 31;
-    const DEPREC = 63;
-    const RFC5322 = 127;
-    const ERR = 255;
+    public const VALID_CATEGORY = 1;
+    public const DNSWARN = 7;
+    public const RFC5321 = 15;
+    public const CFWS = 31;
+    public const DEPREC = 63;
+    public const RFC5322 = 127;
+    public const ERR = 255;
 
     // Diagnoses
     // Address is valid
-    const VALID = 0;
+    public const VALID = 0;
     // Address is valid but a DNS check was not successful
-    const DNSWARN_NO_MX_RECORD = 5;
-    const DNSWARN_NO_RECORD = 6;
+    public const DNSWARN_NO_MX_RECORD = 5;
+    public const DNSWARN_NO_RECORD = 6;
     // Address is valid for SMTP but has unusual elements
-    const RFC5321_TLD = 9;
-    const RFC5321_TLDNUMERIC = 10;
-    const RFC5321_QUOTEDSTRING = 11;
-    const RFC5321_ADDRESSLITERAL = 12;
-    const RFC5321_IPV6DEPRECATED = 13;
+    public const RFC5321_TLD = 9;
+    public const RFC5321_TLDNUMERIC = 10;
+    public const RFC5321_QUOTEDSTRING = 11;
+    public const RFC5321_ADDRESSLITERAL = 12;
+    public const RFC5321_IPV6DEPRECATED = 13;
     // Address is valid within the message but cannot be used unmodified for the envelope
-    const CFWS_COMMENT = 17;
-    const CFWS_FWS = 18;
+    public const CFWS_COMMENT = 17;
+    public const CFWS_FWS = 18;
     // Address contains deprecated elements but may still be valid in restricted contexts
-    const DEPREC_LOCALPART = 33;
-    const DEPREC_FWS = 34;
-    const DEPREC_QTEXT = 35;
-    const DEPREC_QP = 36;
-    const DEPREC_COMMENT = 37;
-    const DEPREC_CTEXT = 38;
-    const DEPREC_CFWS_NEAR_AT = 49;
+    public const DEPREC_LOCALPART = 33;
+    public const DEPREC_FWS = 34;
+    public const DEPREC_QTEXT = 35;
+    public const DEPREC_QP = 36;
+    public const DEPREC_COMMENT = 37;
+    public const DEPREC_CTEXT = 38;
+    public const DEPREC_CFWS_NEAR_AT = 49;
     // The address is only valid according to the broad definition of RFC 5322.
     // It is otherwise invalid.
-    const RFC5322_DOMAIN = 65;
-    const RFC5322_TOOLONG = 66;
-    const RFC5322_LOCAL_TOOLONG = 67;
-    const RFC5322_DOMAIN_TOOLONG = 68;
-    const RFC5322_LABEL_TOOLONG = 69;
-    const RFC5322_DOMAINLITERAL = 70;
-    const RFC5322_DOMLIT_OBSDTEXT = 71;
-    const RFC5322_IPV6_GRPCOUNT = 72;
-    const RFC5322_IPV6_2X2XCOLON = 73;
-    const RFC5322_IPV6_BADCHAR = 74;
-    const RFC5322_IPV6_MAXGRPS = 75;
-    const RFC5322_IPV6_COLONSTRT = 76;
-    const RFC5322_IPV6_COLONEND = 77;
+    public const RFC5322_DOMAIN = 65;
+    public const RFC5322_TOOLONG = 66;
+    public const RFC5322_LOCAL_TOOLONG = 67;
+    public const RFC5322_DOMAIN_TOOLONG = 68;
+    public const RFC5322_LABEL_TOOLONG = 69;
+    public const RFC5322_DOMAINLITERAL = 70;
+    public const RFC5322_DOMLIT_OBSDTEXT = 71;
+    public const RFC5322_IPV6_GRPCOUNT = 72;
+    public const RFC5322_IPV6_2X2XCOLON = 73;
+    public const RFC5322_IPV6_BADCHAR = 74;
+    public const RFC5322_IPV6_MAXGRPS = 75;
+    public const RFC5322_IPV6_COLONSTRT = 76;
+    public const RFC5322_IPV6_COLONEND = 77;
     // Address is invalid for any purpose
-    const ERR_EXPECTING_DTEXT = 129;
-    const ERR_NOLOCALPART = 130;
-    const ERR_NODOMAIN = 131;
-    const ERR_CONSECUTIVEDOTS = 132;
-    const ERR_ATEXT_AFTER_CFWS = 133;
-    const ERR_ATEXT_AFTER_QS = 134;
-    const ERR_ATEXT_AFTER_DOMLIT = 135;
-    const ERR_EXPECTING_QPAIR = 136;
-    const ERR_EXPECTING_ATEXT = 137;
-    const ERR_EXPECTING_QTEXT = 138;
-    const ERR_EXPECTING_CTEXT = 139;
-    const ERR_BACKSLASHEND = 140;
-    const ERR_DOT_START = 141;
-    const ERR_DOT_END = 142;
-    const ERR_DOMAINHYPHENSTART = 143;
-    const ERR_DOMAINHYPHENEND = 144;
-    const ERR_UNCLOSEDQUOTEDSTR = 145;
-    const ERR_UNCLOSEDCOMMENT = 146;
-    const ERR_UNCLOSEDDOMLIT = 147;
-    const ERR_FWS_CRLF_X2 = 148;
-    const ERR_FWS_CRLF_END = 149;
-    const ERR_CR_NO_LF = 150;
+    public const ERR_EXPECTING_DTEXT = 129;
+    public const ERR_NOLOCALPART = 130;
+    public const ERR_NODOMAIN = 131;
+    public const ERR_CONSECUTIVEDOTS = 132;
+    public const ERR_ATEXT_AFTER_CFWS = 133;
+    public const ERR_ATEXT_AFTER_QS = 134;
+    public const ERR_ATEXT_AFTER_DOMLIT = 135;
+    public const ERR_EXPECTING_QPAIR = 136;
+    public const ERR_EXPECTING_ATEXT = 137;
+    public const ERR_EXPECTING_QTEXT = 138;
+    public const ERR_EXPECTING_CTEXT = 139;
+    public const ERR_BACKSLASHEND = 140;
+    public const ERR_DOT_START = 141;
+    public const ERR_DOT_END = 142;
+    public const ERR_DOMAINHYPHENSTART = 143;
+    public const ERR_DOMAINHYPHENEND = 144;
+    public const ERR_UNCLOSEDQUOTEDSTR = 145;
+    public const ERR_UNCLOSEDCOMMENT = 146;
+    public const ERR_UNCLOSEDDOMLIT = 147;
+    public const ERR_FWS_CRLF_X2 = 148;
+    public const ERR_FWS_CRLF_END = 149;
+    public const ERR_CR_NO_LF = 150;
     /*:diagnostic constants end:*/
 
     // function control
-    const THRESHOLD = 16;
+    public const THRESHOLD = 16;
 
     // Email parts
-    const COMPONENT_LOCALPART = 0;
-    const COMPONENT_DOMAIN = 1;
-    const COMPONENT_LITERAL = 2;
-    const CONTEXT_COMMENT = 3;
-    const CONTEXT_FWS = 4;
-    const CONTEXT_QUOTEDSTRING = 5;
-    const CONTEXT_QUOTEDPAIR = 6;
+    public const COMPONENT_LOCALPART = 0;
+    public const COMPONENT_DOMAIN = 1;
+    public const COMPONENT_LITERAL = 2;
+    public const CONTEXT_COMMENT = 3;
+    public const CONTEXT_FWS = 4;
+    public const CONTEXT_QUOTEDSTRING = 5;
+    public const CONTEXT_QUOTEDPAIR = 6;
 
     // Miscellaneous string constants
-    const STRING_AT = '@';
-    const STRING_BACKSLASH = '\\';
-    const STRING_DOT = '.';
-    const STRING_DQUOTE = '"';
-    const STRING_OPENPARENTHESIS = '(';
-    const STRING_CLOSEPARENTHESIS = ')';
-    const STRING_OPENSQBRACKET = '[';
-    const STRING_CLOSESQBRACKET = ']';
-    const STRING_HYPHEN = '-';
-    const STRING_COLON = ':';
-    const STRING_DOUBLECOLON = '::';
-    const STRING_SP = ' ';
-    const STRING_HTAB = "\t";
-    const STRING_CR = "\r";
-    const STRING_LF = "\n";
-    const STRING_IPV6TAG = 'IPv6:';
+    public const STRING_AT = '@';
+    public const STRING_BACKSLASH = '\\';
+    public const STRING_DOT = '.';
+    public const STRING_DQUOTE = '"';
+    public const STRING_OPENPARENTHESIS = '(';
+    public const STRING_CLOSEPARENTHESIS = ')';
+    public const STRING_OPENSQBRACKET = '[';
+    public const STRING_CLOSESQBRACKET = ']';
+    public const STRING_HYPHEN = '-';
+    public const STRING_COLON = ':';
+    public const STRING_DOUBLECOLON = '::';
+    public const STRING_SP = ' ';
+    public const STRING_HTAB = "\t";
+    public const STRING_CR = "\r";
+    public const STRING_LF = "\n";
+    public const STRING_IPV6TAG = 'IPv6:';
 
     // US-ASCII visible characters not valid for atext
     // <http://tools.ietf.org/html/rfc5322#section-3.2.3>
-    const STRING_SPECIALS = '()<>[]:;@\\,."';
+    public const STRING_SPECIALS = '()<>[]:;@\\,."';
 
     /**
      *
@@ -720,7 +721,7 @@ class Email
             // @
             case Email::STRING_AT:
                 // At this point we should have a valid local-part
-                if (count($this->contextStack) !== 1) {
+                if (count((array) $this->contextStack) !== 1) {
                     throw new Exception('Unexpected item on context stack');
                 }
 
@@ -1142,7 +1143,7 @@ class Email
                         } elseif ((substr($IPv6, -1) === Email::STRING_COLON) && (substr($IPv6, -2, 1) !== Email::STRING_COLON)) {
                             // Address ends with a single colon
                             $this->returnStatus[] = Email::RFC5322_IPV6_COLONEND;
-                        } elseif (count(preg_grep('/^[0-9A-Fa-f]{0,4}$/', $matchesIP, PREG_GREP_INVERT)) !== 0) {
+                        } elseif ((is_array(preg_grep('/^[0-9A-Fa-f]{0,4}$/', $matchesIP, PREG_GREP_INVERT)) || preg_grep('/^[0-9A-Fa-f]{0,4}$/', $matchesIP, PREG_GREP_INVERT) instanceof Countable ? count(preg_grep('/^[0-9A-Fa-f]{0,4}$/', $matchesIP, PREG_GREP_INVERT)) : 0) !== 0) {
                             // Check for unmatched characters
                             $this->returnStatus[] = Email::RFC5322_IPV6_BADCHAR;
                         } else {
@@ -1667,11 +1668,11 @@ class Email
                 // Domain can't be found in DNS
                 $this->returnStatus[] = Email::DNSWARN_NO_RECORD;
             } else {
-                if (count($result) === 0) {
+                if ((is_array($result) || $result instanceof Countable ? count($result) : 0) === 0) {
                     // MX-record for domain can't be found
                     $this->returnStatus[] = Email::DNSWARN_NO_MX_RECORD;
                     $result = @dns_get_record($this->parseData[Email::COMPONENT_DOMAIN], DNS_A + DNS_CNAME);
-                    if (count($result) === 0) {
+                    if ((is_array($result) || $result instanceof Countable ? count($result) : 0) === 0) {
                         // No usable records for the domain can be found
                         $this->returnStatus[] = Email::DNSWARN_NO_RECORD;
                     }

--- a/src/Rule/Validate/Isbn.php
+++ b/src/Rule/Validate/Isbn.php
@@ -28,7 +28,7 @@ class Isbn
      * @return bool True if valid, false if not.
      *
      */
-    public function __invoke($subject, $field)
+    public function __invoke(object $subject, string $field)
     {
         $value = $this->normalize($subject, $field);
         if (! $value) {

--- a/src/Rule/Validate/Isbn.php
+++ b/src/Rule/Validate/Isbn.php
@@ -41,14 +41,13 @@ class Isbn
      *
      * Removes all non-ISBN characters to test if it is a valid ISBN.
      *
-     * @param object $subject The subject to be filtered.
      *
      * @param string $field The subject field name.
      *
      * @return string|false The normalized string, or false on failure.
      *
      */
-    public function normalize($subject, $field)
+    public function normalize(object $subject, string $field)
     {
         $value = preg_replace('/(?:(?!([0-9|X$])).)*/', '', $subject->$field);
         if (preg_match('/^[0-9]{10,13}$|^[0-9]{9}X$/', $value)) {
@@ -63,10 +62,9 @@ class Isbn
      *
      * @param $value The value to test.
      *
-     * @return bool
      *
      */
-    protected function isbn13($value)
+    protected function isbn13($value): bool
     {
         if (strlen($value) != 13) {
             return false;
@@ -93,10 +91,9 @@ class Isbn
      *
      * @param $value The value to test.
      *
-     * @return bool
      *
      */
-    protected function isbn10($value)
+    protected function isbn10($value): bool
     {
         if (strlen($value) != 10) {
             return false;

--- a/src/Rule/Validate/Upload.php
+++ b/src/Rule/Validate/Upload.php
@@ -35,7 +35,7 @@ class Upload
      */
     public function __invoke($subject, $field)
     {
-        $value = $subject->$field;
+        $value = (array) $subject->$field;
 
         $well_formed = $this->preCheck($value);
         if (! $well_formed) {
@@ -63,10 +63,9 @@ class Upload
      *
      * @param array $value The file-upload array.
      *
-     * @return bool
      *
      */
-    protected function preCheck(&$value)
+    protected function preCheck(array &$value): bool
     {
         // has to be an array
         if (! is_array($value)) {
@@ -105,7 +104,7 @@ class Upload
      * @return bool True if the file was uploaded via HTTP POST, false if not.
      *
      */
-    protected function isUploadedFile($file)
+    protected function isUploadedFile(string $file): bool
     {
         return is_uploaded_file($file);
     }

--- a/src/Rule/Validate/UploadedFile.php
+++ b/src/Rule/Validate/UploadedFile.php
@@ -26,6 +26,9 @@ class UploadedFile
     const SIZE_MAX       = 'sizeMax';
     const SIZE_MIN       = 'sizeMin';
 
+    /**
+     * @var string[]
+     */
     protected $rules = array(
         self::REQUIRED,
         self::FILE_EXTENSION,
@@ -79,11 +82,10 @@ class UploadedFile
      *
      * @param array $options the options passed tot the filter
      *
-     * @return bool
      *
      * @access protected
      */
-    protected function isRequired(array $options)
+    protected function isRequired(array $options): bool
     {
         return (
             isset($options[self::REQUIRED])
@@ -96,11 +98,10 @@ class UploadedFile
      *
      * @param mixed $value value being validated
      *
-     * @return bool
      *
      * @access protected
      */
-    protected function isUploadedFile($value)
+    protected function isUploadedFile($value): bool
     {
         return ($value instanceof UploadedFileInterface);
     }
@@ -110,11 +111,10 @@ class UploadedFile
      *
      * @param mixed $value value being validated
      *
-     * @return bool
      *
      * @access protected
      */
-    protected function fileWasUploaded($value)
+    protected function fileWasUploaded($value): bool
     {
         if (! $this->isUploadedFile($value)) {
             return false;
@@ -133,11 +133,10 @@ class UploadedFile
      * @param mixed $value  value being validated
      * @param bool  $option if the file is required
      *
-     * @return bool
      *
      * @access protected
      */
-    protected function required($value, $option)
+    protected function required($value, bool $option): bool
     {
         if ($option === false) {
             return true;
@@ -152,11 +151,10 @@ class UploadedFile
      * @param mixed        $value value being validated
      * @param string|array $exts  array or string of valid extensions
      *
-     * @return bool
      *
      * @access protected
      */
-    protected function fileExtension($value, $exts)
+    protected function fileExtension($value, $exts): bool
     {
         $filename = $value->getClientFilename();
         $ext = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
@@ -169,11 +167,10 @@ class UploadedFile
      * @param mixed        $value  value being validated
      * @param string|array $medias array or string of valid media types
      *
-     * @return bool
      *
      * @access protected
      */
-    protected function fileMedia($value, $medias)
+    protected function fileMedia($value, $medias): bool
     {
         $media = $value->getClientMediaType();
         return in_array($media, (array) $medias);
@@ -185,11 +182,10 @@ class UploadedFile
      * @param mixed $value value being validated
      * @param mixed $max   maximum file size
      *
-     * @return bool
      *
      * @access protected
      */
-    protected function sizeMax($value, $max)
+    protected function sizeMax($value, $max): bool
     {
         $size = $value->getSize();
         return $size < $this->parseHumanSize($max);
@@ -205,7 +201,7 @@ class UploadedFile
      *
      * @access protected
      */
-    protected function sizeMin($value, $min)
+    protected function sizeMin($value, $min): bool
     {
         $size = $value->getSize();
         return $size > $this->parseHumanSize($min);

--- a/src/Rule/Validate/UploadedFile.php
+++ b/src/Rule/Validate/UploadedFile.php
@@ -20,11 +20,11 @@ use Psr\Http\Message\UploadedFileInterface;
 class UploadedFile
 {
 
-    const REQUIRED       = 'required';
-    const FILE_EXTENSION = 'fileExtension';
-    const FILE_MEDIA     = 'fileMedia';
-    const SIZE_MAX       = 'sizeMax';
-    const SIZE_MIN       = 'sizeMin';
+    public const REQUIRED       = 'required';
+    public const FILE_EXTENSION = 'fileExtension';
+    public const FILE_MEDIA     = 'fileMedia';
+    public const SIZE_MAX       = 'sizeMax';
+    public const SIZE_MIN       = 'sizeMin';
 
     /**
      * @var string[]

--- a/src/Spec/SanitizeSpec.php
+++ b/src/Spec/SanitizeSpec.php
@@ -74,10 +74,9 @@ class SanitizeSpec extends Spec
      *
      * @param ...$args Arguments for the rule.
      *
-     * @return self
      *
      */
-    public function to($rule)
+    public function to(string $rule): Spec
     {
         $this->allow_blank = false;
         return $this->init(func_get_args());
@@ -91,10 +90,9 @@ class SanitizeSpec extends Spec
      *
      * @param ...$args Arguments for the rule.
      *
-     * @return self
      *
      */
-    public function toBlankOr($rule)
+    public function toBlankOr(string $rule): Spec
     {
         $this->allow_blank = true;
         return $this->init(func_get_args());
@@ -106,10 +104,9 @@ class SanitizeSpec extends Spec
      *
      * @param mixed $blank_value Replace the blank field with this value.
      *
-     * @return self
      *
      */
-    public function useBlankValue($blank_value)
+    public function useBlankValue($blank_value): self
     {
         $this->allow_blank = true;
         $this->blank_value = $blank_value;
@@ -122,10 +119,9 @@ class SanitizeSpec extends Spec
      *
      * @param string $field_name Replace the blank field with the value from field.
      *
-     * @return self
      *
      */
-    public function useBlankField($field_name)
+    public function useBlankField(string $field_name): self
     {
         $this->blank_field = $field_name;
         return $this;
@@ -135,10 +131,9 @@ class SanitizeSpec extends Spec
      *
      * Returns the default failure message for this rule specification.
      *
-     * @return string
      *
      */
-    protected function getDefaultMessage()
+    protected function getDefaultMessage(): string
     {
         return $this->field . ' should have sanitized to '
              . parent::getDefaultMessage();

--- a/src/Spec/Spec.php
+++ b/src/Spec/Spec.php
@@ -24,17 +24,17 @@ class Spec
     /**
      * Stop filtering on a field when a rule for that field fails.
      */
-    const HARD_RULE = 'HARD_RULE';
+    public const HARD_RULE = 'HARD_RULE';
 
     /**
      * Continue filtering on a field even when a rule for that field fails.
      */
-    const SOFT_RULE = 'SOFT_RULE';
+    public const SOFT_RULE = 'SOFT_RULE';
 
     /**
      * Stop filtering on all fields when a rule fails.
      */
-    const STOP_RULE = 'STOP_RULE';
+    public const STOP_RULE = 'STOP_RULE';
 
     /**
      *
@@ -155,7 +155,7 @@ class Spec
      * @return self
      *
      */
-    public function asSoftRule($message = null): \Aura\Filter\Spec\Spec
+    public function asSoftRule(?string $message = null): \Aura\Filter\Spec\Spec
     {
         return $this->setFailureMode(self::SOFT_RULE, $message);
     }
@@ -169,7 +169,7 @@ class Spec
      * @return self
      *
      */
-    public function asHardRule($message = null): \Aura\Filter\Spec\Spec
+    public function asHardRule(?string $message = null): \Aura\Filter\Spec\Spec
     {
         return $this->setFailureMode(self::HARD_RULE, $message);
     }
@@ -183,7 +183,7 @@ class Spec
      * @return self
      *
      */
-    public function asStopRule($message = null): \Aura\Filter\Spec\Spec
+    public function asStopRule(?string $message = null): \Aura\Filter\Spec\Spec
     {
         return $this->setFailureMode(self::STOP_RULE, $message);
     }

--- a/src/Spec/Spec.php
+++ b/src/Spec/Spec.php
@@ -140,7 +140,7 @@ class Spec
      * @return self
      *
      */
-    public function field($field)
+    public function field(string $field)
     {
         $this->field = $field;
         return $this;
@@ -155,7 +155,7 @@ class Spec
      * @return self
      *
      */
-    public function asSoftRule($message = null)
+    public function asSoftRule($message = null): \Aura\Filter\Spec\Spec
     {
         return $this->setFailureMode(self::SOFT_RULE, $message);
     }
@@ -169,7 +169,7 @@ class Spec
      * @return self
      *
      */
-    public function asHardRule($message = null)
+    public function asHardRule($message = null): \Aura\Filter\Spec\Spec
     {
         return $this->setFailureMode(self::HARD_RULE, $message);
     }
@@ -183,7 +183,7 @@ class Spec
      * @return self
      *
      */
-    public function asStopRule($message = null)
+    public function asStopRule($message = null): \Aura\Filter\Spec\Spec
     {
         return $this->setFailureMode(self::STOP_RULE, $message);
     }
@@ -199,7 +199,7 @@ class Spec
      * @return self
      *
      */
-    protected function setFailureMode($failure_mode, $message)
+    protected function setFailureMode(string $failure_mode, ?string $message)
     {
         $this->failure_mode = $failure_mode;
         if ($message) {
@@ -217,7 +217,7 @@ class Spec
      * @return self
      *
      */
-    public function setMessage($message)
+    public function setMessage(string $message)
     {
         $this->message = $message;
         return $this;
@@ -307,7 +307,7 @@ class Spec
      * @return self
      *
      */
-    protected function init($args)
+    protected function init(array $args)
     {
         $this->args = $args;
         $this->rule = array_shift($this->args);

--- a/src/Spec/SubSpec.php
+++ b/src/Spec/SubSpec.php
@@ -58,11 +58,10 @@ class SubSpec extends Spec
     /**
      * Get the Subject filter
      *
-     * @return SubjectFilter
      *
      * @access public
      */
-    public function filter()
+    public function filter(): SubjectFilter
     {
         return $this->filter;
     }
@@ -70,11 +69,11 @@ class SubSpec extends Spec
     /**
      * Returns the default failure message for this rule specification.
      *
-     * @return array
      *
      * @access protected
+     * @return mixed[][]
      */
-    protected function getDefaultMessage()
+    protected function getDefaultMessage(): array
     {
         return $this->filter
             ->getFailures()

--- a/src/Spec/SubSpecFactory.php
+++ b/src/Spec/SubSpecFactory.php
@@ -12,7 +12,7 @@ class SubSpecFactory
         $this->factory = $factory;
     }
 
-    public function newSubSpec($class = 'Aura\Filter\SubjectFilter')
+    public function newSubSpec($class = 'Aura\Filter\SubjectFilter'): SubSpec
     {
         $subject = $this->factory->newSubjectFilter($class);
         return new SubSpec($subject);

--- a/src/Spec/SubSpecFactory.php
+++ b/src/Spec/SubSpecFactory.php
@@ -3,6 +3,7 @@
 
 namespace Aura\Filter\Spec;
 
+use Aura\Filter\SubjectFilter;
 class SubSpecFactory
 {
     protected $factory;
@@ -12,7 +13,7 @@ class SubSpecFactory
         $this->factory = $factory;
     }
 
-    public function newSubSpec($class = 'Aura\Filter\SubjectFilter'): SubSpec
+    public function newSubSpec($class = SubjectFilter::class): SubSpec
     {
         $subject = $this->factory->newSubjectFilter($class);
         return new SubSpec($subject);

--- a/src/Spec/ValidateSpec.php
+++ b/src/Spec/ValidateSpec.php
@@ -60,10 +60,9 @@ class ValidateSpec extends Spec
      *
      * @param ...$args Arguments for the rule.
      *
-     * @return self
      *
      */
-    public function is($rule)
+    public function is(string $rule): Spec
     {
         $this->allow_blank = false;
         $this->reverse = false;
@@ -74,10 +73,9 @@ class ValidateSpec extends Spec
      *
      * Validate the field is blank.
      *
-     * @return self
      *
      */
-    public function isBlank()
+    public function isBlank(): Spec
     {
         $this->allow_blank = true;
         $this->reverse = false;
@@ -92,10 +90,9 @@ class ValidateSpec extends Spec
      *
      * @param ...$args Arguments for the rule.
      *
-     * @return self
      *
      */
-    public function isBlankOr($rule)
+    public function isBlankOr(string $rule): Spec
     {
         $this->allow_blank = true;
         $this->reverse = false;
@@ -110,10 +107,9 @@ class ValidateSpec extends Spec
      *
      * @param ...$args Arguments for the rule.
      *
-     * @return self
      *
      */
-    public function isNot($rule)
+    public function isNot(string $rule): Spec
     {
         $this->allow_blank = false;
         $this->reverse = true;
@@ -124,10 +120,9 @@ class ValidateSpec extends Spec
      *
      * Validate the field is not blank.
      *
-     * @return self
      *
      */
-    public function isNotBlank()
+    public function isNotBlank(): Spec
     {
         $this->allow_blank = false;
         $this->reverse = true;
@@ -142,10 +137,9 @@ class ValidateSpec extends Spec
      *
      * @param ...$args Arguments for the rule.
      *
-     * @return self
      *
      */
-    public function isBlankOrNot($rule)
+    public function isBlankOrNot(string $rule): Spec
     {
         $this->allow_blank = true;
         $this->reverse = true;
@@ -156,10 +150,9 @@ class ValidateSpec extends Spec
      *
      * Returns the default failure message for this rule specification.
      *
-     * @return string
      *
      */
-    protected function getDefaultMessage()
+    protected function getDefaultMessage(): string
     {
         $message = $this->field . ' should';
 

--- a/src/SubjectFilter.php
+++ b/src/SubjectFilter.php
@@ -218,7 +218,7 @@ class SubjectFilter
      *
      *
      */
-    public function subfilter(string $field, $class = 'Aura\Filter\SubjectFilter'): Spec
+    public function subfilter(string $field, $class = \Aura\Filter\SubjectFilter::class): Spec
     {
         $spec = $this->sub_spec_factory->newSubSpec($class);
         return $this->addSpec($spec, $field);

--- a/src/SubjectFilter.php
+++ b/src/SubjectFilter.php
@@ -8,6 +8,7 @@
  */
 namespace Aura\Filter;
 
+use Aura\Filter\Exception\FilterFailed;
 use Aura\Filter\Exception;
 use Aura\Filter\Failure\Failure;
 use Aura\Filter\Failure\FailureCollection;
@@ -132,7 +133,7 @@ class SubjectFilter
      * @return null
      *
      */
-    protected function init()
+    protected function init(): void
     {
         // do nothing
     }
@@ -164,7 +165,7 @@ class SubjectFilter
      * @throws Exception\FilterFailed when the assertion fails.
      *
      */
-    public function assert(&$subject)
+    public function assert(&$subject): void
     {
         if ($this->apply($subject)) {
             return;
@@ -176,7 +177,7 @@ class SubjectFilter
                  . "  Fields:" . PHP_EOL
                  . $this->failures->getMessagesAsString('    ');
 
-        $e = new Exception\FilterFailed($message);
+        $e = new FilterFailed($message);
         $e->setFilterClass($class);
         $e->setFailures($this->failures);
         $e->setSubject($subject);
@@ -189,10 +190,9 @@ class SubjectFilter
      *
      * @param string $field The subject field name.
      *
-     * @return ValidateSpec
      *
      */
-    public function validate($field)
+    public function validate(string $field): Spec
     {
         return $this->addSpec(clone $this->validate_spec, $field);
     }
@@ -203,10 +203,9 @@ class SubjectFilter
      *
      * @param string $field The subject field name.
      *
-     * @return SanitizeSpec
      *
      */
-    public function sanitize($field)
+    public function sanitize(string $field): Spec
     {
         return $this->addSpec(clone $this->sanitize_spec, $field);
     }
@@ -217,10 +216,9 @@ class SubjectFilter
      *
      * @param string $field The subject field name.
      *
-     * @return SubSpec
      *
      */
-    public function subfilter($field, $class = 'Aura\Filter\SubjectFilter')
+    public function subfilter(string $field, $class = 'Aura\Filter\SubjectFilter'): Spec
     {
         $spec = $this->sub_spec_factory->newSubSpec($class);
         return $this->addSpec($spec, $field);
@@ -234,10 +232,9 @@ class SubjectFilter
      *
      * @param string $field The subject field name.
      *
-     * @return Spec
      *
      */
-    protected function addSpec($spec, $field)
+    protected function addSpec(Spec $spec, string $field): Spec
     {
         $this->specs[] = $spec;
         $spec->field($field);
@@ -255,7 +252,7 @@ class SubjectFilter
      * @return null
      *
      */
-    public function useFieldMessage($field, $message)
+    public function useFieldMessage(string $field, string $message): void
     {
         $this->field_messages[$field] = $message;
     }
@@ -269,7 +266,7 @@ class SubjectFilter
      * @return bool True on success, false on failure.
      *
      */
-    public function apply(&$subject)
+    public function apply(&$subject): bool
     {
         if (is_array($subject)) {
             return $this->applyToArray($subject);
@@ -293,7 +290,7 @@ class SubjectFilter
      * @return bool True if all rules passed, false if not.
      *
      */
-    protected function applyToArray(&$array)
+    protected function applyToArray(array &$array): bool
     {
         $object = (object) $array;
         $result = $this->applyToObject($object);
@@ -305,12 +302,11 @@ class SubjectFilter
      *
      * Applies the rule specifications to an object.
      *
-     * @param object $object The filter subject.
      *
      * @return bool True if all rules passed, false if not.
      *
      */
-    protected function applyToObject($object)
+    protected function applyToObject(object $object): bool
     {
         $this->skip = array();
         $this->failures = clone $this->proto_failures;
@@ -329,12 +325,11 @@ class SubjectFilter
      *
      * @param Spec $spec The rule specification.
      *
-     * @param object $subject The filter subject.
      *
      * @return bool True to continue, false to stop.
      *
      */
-    protected function applySpec($spec, $subject)
+    protected function applySpec(Spec $spec, object $subject): bool
     {
         if (isset($this->skip[$spec->getField()])) {
 
@@ -366,10 +361,9 @@ class SubjectFilter
      *
      * @param Spec $spec The failed rule specification.
      *
-     * @return Failure
      *
      */
-    protected function failed($spec)
+    protected function failed(Spec $spec): Failure
     {
         $field = $spec->getField();
 
@@ -388,10 +382,9 @@ class SubjectFilter
      *
      * Returns the failures.
      *
-     * @return FailureCollection
      *
      */
-    public function getFailures()
+    public function getFailures(): FailureCollection
     {
         return $this->failures;
     }

--- a/src/ValueFilter.php
+++ b/src/ValueFilter.php
@@ -8,6 +8,7 @@
  */
 namespace Aura\Filter;
 
+use stdClass;
 use Aura\Filter\Locator\Locator;
 use Aura\Filter\Locator\SanitizeLocator;
 use Aura\Filter\Locator\ValidateLocator;
@@ -25,8 +26,7 @@ class ValueFilter
      *
      * A pseudo-subject to hold the value being filtered.
      *
-     * @var object
-     *
+     * @var stdClass
      */
     protected $subject;
 
@@ -63,7 +63,7 @@ class ValueFilter
      * @return bool True on success, false on failure.
      *
      */
-    public function validate($value, $rule)
+    public function validate($value, string $rule): bool
     {
         $this->subject->value = $value;
         return $this->apply($this->validate_locator, func_get_args());
@@ -82,7 +82,7 @@ class ValueFilter
      * @return bool True on success, false on failure.
      *
      */
-    public function sanitize(&$value, $rule)
+    public function sanitize(&$value, string $rule): bool
     {
         $this->subject->value =& $value;
         return $this->apply($this->sanitize_locator, func_get_args());
@@ -94,12 +94,12 @@ class ValueFilter
      *
      * @param Locator $locator A rule locator.
      *
-     * @param string $args Arguments for the rule.
+     * @param array $args Arguments for the rule.
      *
      * @return bool True on success, false on failure.
      *
      */
-    protected function apply(Locator $locator, $args)
+    protected function apply(Locator $locator, array $args): bool
     {
         array_shift($args); // remove $value
         $rule = array_shift($args); // remove $rule

--- a/tests/Rule/FakeCharCase.php
+++ b/tests/Rule/FakeCharCase.php
@@ -3,22 +3,22 @@ namespace Aura\Filter\Rule;
 
 class FakeCharCase extends AbstractCharCase
 {
-    protected function mbstring()
+    protected function mbstring(): bool
     {
         return false;
     }
 
-    public function strtolower($str)
+    public function strtolower($str): string
     {
         return parent::strtolower($str);
     }
 
-    public function strtoupper($str)
+    public function strtoupper($str): string
     {
         return parent::strtoupper($str);
     }
 
-    public function ucwords($str)
+    public function ucwords($str): string
     {
         return parent::ucwords($str);
     }

--- a/tests/Rule/FakeStrlen.php
+++ b/tests/Rule/FakeStrlen.php
@@ -3,22 +3,22 @@ namespace Aura\Filter\Rule;
 
 class FakeStrlen extends AbstractStrlen
 {
-    protected function iconv()
+    protected function iconv(): bool
     {
         return false;
     }
 
-    protected function mbstring()
+    protected function mbstring(): bool
     {
         return false;
     }
 
-    public function strlen($str)
+    public function strlen($str): int
     {
         return parent::strlen($str);
     }
 
-    public function substr($str, $start, $length = null)
+    public function substr($str, $start, $length = null): string
     {
         return parent::substr($str, $start, $length);
     }

--- a/tests/Rule/FakeStrlenIconv.php
+++ b/tests/Rule/FakeStrlenIconv.php
@@ -3,17 +3,17 @@ namespace Aura\Filter\Rule;
 
 class FakeStrlenIconv extends AbstractStrlen
 {
-    protected function mbstring()
+    protected function mbstring(): bool
     {
         return false;
     }
 
-    public function strlen($str)
+    public function strlen($str): int
     {
         return parent::strlen($str);
     }
 
-    public function substr($str, $start, $length = null)
+    public function substr($str, $start, $length = null): string
     {
         return parent::substr($str, $start, $length);
     }

--- a/tests/Rule/FakeStrlenMbstring.php
+++ b/tests/Rule/FakeStrlenMbstring.php
@@ -3,17 +3,17 @@ namespace Aura\Filter\Rule;
 
 class FakeStrlenMbstring extends AbstractStrlen
 {
-    protected function iconv()
+    protected function iconv(): bool
     {
         return false;
     }
 
-    public function strlen($str)
+    public function strlen($str): int
     {
         return parent::strlen($str);
     }
 
-    public function substr($str, $start, $length = null)
+    public function substr($str, $start, $length = null): string
     {
         return parent::substr($str, $start, $length);
     }

--- a/tests/Rule/Validate/FakeUpload.php
+++ b/tests/Rule/Validate/FakeUpload.php
@@ -5,7 +5,7 @@ class FakeUpload extends Upload
 {
     public $is_uploaded_file = true;
 
-    protected function isUploadedFile($file)
+    protected function isUploadedFile(string $file): bool
     {
         // hit the parent method ...
         parent::isUploadedFile($file);


### PR DESCRIPTION
Using rector to make the necessary changes to code for type hint and other auto rules.

Current `rector.php`

```php
<?php

declare(strict_types=1);

use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
use Rector\Core\Configuration\Option;
use Rector\Set\ValueObject\SetList;
use Rector\Set\ValueObject\LevelSetList;

return static function (ContainerConfigurator $containerConfigurator): void {
    // get parameters
    $parameters = $containerConfigurator->parameters();

    $parameters->set(Option::PATHS, [
        __DIR__ . '/src'
    ]);

    $parameters->set(Option::SKIP, [
        'src/Locator/ValidateLocator.php',
        'src/Locator/SanitizeLocator.php',
    ]);

    $parameters->set(Option::AUTO_IMPORT_NAMES, true);
    $containerConfigurator->import(LevelSetList::UP_TO_PHP_72);
    $containerConfigurator->import(SetList::PHP_72);
    $containerConfigurator->import(SetList::TYPE_DECLARATION);
    $containerConfigurator->import(SetList::TYPE_DECLARATION_STRICT);
};
```