### PR TITLE
Enable PHP 8.2 compat

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
         uses: actions/cache@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,6 +20,7 @@ jobs:
           - '7.4'
           - '8.0'
           - '8.1'
+          - '8.2'
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "autoload": {
         "psr-4": {
             "Aura\\Filter\\": "src/"
-        }
+        },
+        "files": ["utf8_to_iso8859_1.php"]
     },
     "suggest": {
         "ext-iconv": "To support UTF-8 in string-length filters.",

--- a/src/Rule/AbstractCharCase.php
+++ b/src/Rule/AbstractCharCase.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  */
 namespace Aura\Filter\Rule;
 
-use Aura\Filter\Exception;
+use function Aura\Filter\utf8_to_iso8859_1;
 
 /**
  *
@@ -38,7 +38,7 @@ abstract class AbstractCharCase extends AbstractStrlen
             return mb_convert_case($str, MB_CASE_LOWER, 'UTF-8');
         }
 
-        return strtolower(utf8_decode($str));
+        return strtolower(utf8_to_iso8859_1($str));
     }
 
     /**
@@ -57,7 +57,7 @@ abstract class AbstractCharCase extends AbstractStrlen
             return mb_convert_case($str, MB_CASE_UPPER, 'UTF-8');
         }
 
-        return strtoupper(utf8_decode($str));
+        return strtoupper(utf8_to_iso8859_1($str));
     }
 
     /**
@@ -75,7 +75,7 @@ abstract class AbstractCharCase extends AbstractStrlen
             return mb_convert_case($str, MB_CASE_TITLE, 'UTF-8');
         }
 
-        return ucwords(utf8_decode($str));
+        return ucwords(utf8_to_iso8859_1($str));
     }
 
     /**

--- a/src/Rule/AbstractDateTime.php
+++ b/src/Rule/AbstractDateTime.php
@@ -50,7 +50,7 @@ abstract class AbstractDateTime
 
         // invalid dates (like 1979-02-29) show up as warnings.
         $errors = DateTime::getLastErrors();
-        if ($errors['warnings']) {
+        if (is_array($errors) && $errors['warnings']) {
             return false;
         }
 

--- a/src/Rule/AbstractStrlen.php
+++ b/src/Rule/AbstractStrlen.php
@@ -13,6 +13,8 @@ namespace Aura\Filter\Rule;
 use Aura\Filter\Exception\MalformedUtf8;
 use Aura\Filter\Exception;
 
+use function Aura\Filter\utf8_to_iso8859_1;
+
 /**
  *
  * Abstract rule for string-length filters; supports the `iconv` and `mbstring`
@@ -67,7 +69,7 @@ abstract class AbstractStrlen
             return mb_strlen($str, 'UTF-8');
         }
 
-        return strlen(utf8_decode($str));
+        return strlen(utf8_to_iso8859_1($str));
     }
 
      /**

--- a/src/ValueFilter.php
+++ b/src/ValueFilter.php
@@ -33,6 +33,16 @@ class ValueFilter
     protected $subject;
 
     /**
+     * @var ValidateLocator
+     */
+    protected $validate_locator;
+
+    /**
+     * @var SanitizeLocator
+     */
+    protected $sanitize_locator;
+
+    /**
      *
      * Constructor.
      *

--- a/utf8_to_iso8859_1.php
+++ b/utf8_to_iso8859_1.php
@@ -1,0 +1,33 @@
+<?php
+namespace Aura\Filter;
+
+function utf8_to_iso8859_1(string $string): string
+{
+    $s = $string;
+    $len = \strlen($s);
+
+    for ($i = 0, $j = 0; $i < $len; ++$i, ++$j) {
+        switch ($s[$i] & "\xF0") {
+            case "\xC0":
+            case "\xD0":
+                $c = (\ord($s[$i] & "\x1F") << 6) | \ord($s[++$i] & "\x3F");
+                $s[$j] = $c < 256 ? \chr($c) : '?';
+                break;
+
+            case "\xF0":
+                ++$i;
+            // no break
+
+            case "\xE0":
+                $s[$j] = '?';
+                $i += 2;
+                break;
+
+            default:
+                $s[$j] = $s[$i];
+        }
+    }
+
+    return substr($s, 0, $j);
+}
+


### PR DESCRIPTION
`utf8_decode` is deprecated with PHP 8.2.
See https://php.watch/versions/8.2/utf8_encode-utf8_decode-deprecated .