### PR TITLE
Fix empty domain handling in Email validation and add PHP 8.3/8.4 support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,6 +21,8 @@ jobs:
           - '8.0'
           - '8.1'
           - '8.2'
+          - '8.3'
+          - '8.4'
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/src/Rule/AbstractStrlen.php
+++ b/src/Rule/AbstractStrlen.php
@@ -72,7 +72,7 @@ abstract class AbstractStrlen
         return strlen(utf8_to_iso8859_1($str));
     }
 
-     /**
+    /**
      *
      * Wrapper for `iconv_substr()` to throw an exception on malformed UTF-8.
      *
@@ -87,10 +87,10 @@ abstract class AbstractStrlen
      * @throws Exception\MalformedUtf8
      *
      */
-    protected function substrIconv(string $str,int $start,int $length)
+    protected function substrIconv(string $str, int $start, ?int $length = null): string
     {
         $level = error_reporting(0);
-        $substr = iconv_substr($str,$start,$length, 'UTF-8');
+        $substr = iconv_substr($str, $start, $length ?? 0, 'UTF-8');
         error_reporting($level);
 
         if ($substr !== false) {
@@ -111,7 +111,7 @@ abstract class AbstractStrlen
      * @throws Exception\MalformedUtf8
      *
      */
-    protected function strlenIconv(string $str)
+    protected function strlenIconv(string $str): int
     {
         $level = error_reporting(0);
         $strlen = iconv_strlen($str, 'UTF-8');

--- a/src/Rule/Validate/Email.php
+++ b/src/Rule/Validate/Email.php
@@ -404,15 +404,24 @@ class Email
      */
     protected function idnToAscii(string $email): string
     {
-        $parts = explode('@', $email);
-        $domain = array_pop($parts);
-        if (! $parts) {
-            // no parts remaining, so no @ symbol, so not valid to begin with
+        if (strpos($email, '@') === false) {
             return $email;
         }
 
-        // put the parts back together, with the domain part converted to ascii
-        return implode('@', $parts) . '@' . idn_to_ascii($domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
+        $parts = explode('@', $email);
+
+        if (!isset($parts[1]) || empty($parts[1])) {
+            return $email;
+        }
+
+        $domain = array_pop($parts);
+        $localPart = implode('@', $parts);
+
+        $asciiDomain = idn_to_ascii($domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
+        if ($asciiDomain === false) {
+            return $email;
+        }
+        return $localPart . '@' . $asciiDomain;
     }
 
     /**


### PR DESCRIPTION
This PR provides two improvements:

1. Fixes empty domain handling in Email validation which causes errors in newer PHP versions
2. Adds explicit testing for PHP 8.3 and PHP 8.4

### Changes

- Enhanced domain validation in `idnToAscii` method to handle empty domains properly
- Early return for invalid email formats
- Added CI testing for PHP 8.3 and PHP 8.4
