### PR TITLE
Fix PHP 8.4 deprecation in AbstractStrlen::substr()

### DIFF
--- a/src/Rule/AbstractStrlen.php
+++ b/src/Rule/AbstractStrlen.php
@@ -138,7 +138,7 @@ abstract class AbstractStrlen
      * @return string
      *
      */
-    protected function substr(string $str, int $start, int $length = null): string
+    protected function substr(string $str, int $start, ?int $length = null): string
     {
         if ($this->iconv()) {
             return $this->substrIconv($str, $start, $length);


### PR DESCRIPTION
Fix deprecation warning by explicitly marking the $length parameter as nullable (?int) in AbstractStrlen::substr() method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type safety and static analysis compatibility for better code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->