### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,7 @@ jobs:
           - '8.4'
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Setup PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
@@ -40,7 +40,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -53,6 +53,6 @@ jobs:
         run: php -d xdebug.mode=coverage ./vendor/bin/phpunit --coverage-clover=coverage.xml
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,8 +1,13 @@
 build:
+    image: default-jammy
+    environment:
+        php:
+            version: 8.4
     nodes:
         analysis:
             tests:
                 override:
                     - php-scrutinizer-run
+
 filter:
     paths: ["src/*"]


### PR DESCRIPTION
Update actions/checkout, actions/cache, and codecov/codecov-action to their latest v4 versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded continuous integration tooling to newer action versions to keep automation current and reliable; no behavioral changes to workflows.
  * Updated CI/static-analysis environment image and set PHP to 8.4 for analysis/build runs, aligning checks with a newer platform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->