### PR TITLE
Added multidimensional array support to Aura.Filter by fixing the shallow cast bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "psr/http-message": "^1.0.0",
-        "aura/filter-interface":"4.x-dev"
+        "aura/filter-interface": "5.x-dev"
     },
     "autoload": {
         "psr-4": {

--- a/src/Spec/SubSpec.php
+++ b/src/Spec/SubSpec.php
@@ -90,13 +90,19 @@ class SubSpec extends Spec
      * Recursively converts a stdClass back to an array so that sanitized
      * values are returned in the original data structure.
      *
+     * Only stdClass nodes are converted — objects that were not created by
+     * arrayToObject() (e.g. DTOs passed in the original input data) are
+     * returned as-is to avoid incorrectly flattening them.
+     *
      * @param object $obj
      */
     private function objectToArray(object $obj): array
     {
         $arr = [];
         foreach ((array) $obj as $key => $value) {
-            $arr[$key] = is_object($value) ? $this->objectToArray($value) : $value;
+            $arr[$key] = $value instanceof \stdClass
+                ? $this->objectToArray($value)
+                : $value;
         }
         return $arr;
     }

--- a/src/Spec/SubSpec.php
+++ b/src/Spec/SubSpec.php
@@ -42,7 +42,13 @@ class SubSpec extends Spec
     }
 
     /**
-     * Apply sub filter to sub subject
+     * Apply sub filter to sub subject.
+     *
+     * If the field value is an array it is converted to a stdClass before
+     * filtering so sub-filter rules can access nested values as properties,
+     * then converted back afterwards so sanitized values are written through
+     * to the caller. Fields that are not targeted by a subfilter are never
+     * touched and continue to reach their own rules as arrays.
      *
      * @param mixed $subject parent subject
      *
@@ -52,9 +58,47 @@ class SubSpec extends Spec
      */
     public function __invoke($subject)
     {
-        $field = $this->field;
+        $field  = $this->field;
         $values =& $subject->$field;
+
+        if (is_array($values)) {
+            $obj    = $this->arrayToObject($values);
+            $result = $this->filter->apply($obj);
+            $values = $this->objectToArray($obj);
+            return $result;
+        }
+
         return $this->filter->apply($values);
+    }
+
+    /**
+     * Recursively converts an array to a stdClass so nested values are
+     * reachable as object properties inside the sub-filter.
+     *
+     * @param array $array
+     */
+    private function arrayToObject(array $array): object
+    {
+        $obj = new \stdClass();
+        foreach ($array as $key => $value) {
+            $obj->$key = is_array($value) ? $this->arrayToObject($value) : $value;
+        }
+        return $obj;
+    }
+
+    /**
+     * Recursively converts a stdClass back to an array so that sanitized
+     * values are returned in the original data structure.
+     *
+     * @param object $obj
+     */
+    private function objectToArray(object $obj): array
+    {
+        $arr = [];
+        foreach ((array) $obj as $key => $value) {
+            $arr[$key] = is_object($value) ? $this->objectToArray($value) : $value;
+        }
+        return $arr;
     }
 
     /**

--- a/src/Spec/SubSpec.php
+++ b/src/Spec/SubSpec.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace Aura\Filter\Spec;
 
-use Aura\Filter\SubjectFilter;
+use Aura\Filter_Interface\SubjectFilterInterface;
 
 /**
  * A specification for a "sub" subject
@@ -23,7 +23,7 @@ class SubSpec extends Spec
     /**
      * Subject Filter
      *
-     * @var SubjectFilter
+     * @var SubjectFilterInterface
      *
      * @access protected
      */
@@ -32,11 +32,11 @@ class SubSpec extends Spec
     /**
      * __construct
      *
-     * @param SubjectFilter $filter The filter to apply to the sub subject
+     * @param SubjectFilterInterface $filter The filter to apply to the sub subject
      *
      * @access public
      */
-    public function __construct(SubjectFilter $filter)
+    public function __construct(SubjectFilterInterface $filter)
     {
         $this->filter = $filter;
     }
@@ -63,7 +63,7 @@ class SubSpec extends Spec
      *
      * @access public
      */
-    public function filter(): SubjectFilter
+    public function filter(): SubjectFilterInterface
     {
         return $this->filter;
     }

--- a/src/SubjectFilter.php
+++ b/src/SubjectFilter.php
@@ -380,6 +380,27 @@ class SubjectFilter implements SubjectFilterInterface
             return $this->failures->set($field, $this->field_messages[$field]);
         }
 
+        // Sub-filters carry their own FailureCollection keyed by sub-field
+        // names. Propagate those directly into the parent so callers can
+        // inspect individual nested failures (e.g. 'city' not just 'address').
+        if ($spec instanceof SubSpec) {
+            $lastFailure = null;
+            foreach ($spec->filter()->getFailures() as $subField => $failures) {
+                foreach ($failures as $failure) {
+                    $lastFailure = $this->failures->add(
+                        $subField,
+                        $failure->getMessage(),
+                        $failure->getArgs()
+                    );
+                }
+            }
+            if ($lastFailure !== null) {
+                return $lastFailure;
+            }
+            // Fallback: sub-filter failed but reported no individual failures.
+            return $this->failures->add($field, 'subfilter failed');
+        }
+
         return $this->failures->add($field, $spec->getMessage(), $spec->getArgs());
     }
 

--- a/src/SubjectFilter.php
+++ b/src/SubjectFilter.php
@@ -19,7 +19,6 @@ use Aura\Filter\Spec\Spec;
 use Aura\Filter\Spec\ValidateSpec;
 use Aura\Filter\Spec\SubSpecFactory;
 use Aura\Filter\Spec\SubSpec;
-use Aura\Filter_Interface\FilterInterface;
 use Aura\Filter_Interface\SubjectFilterInterface;
 use InvalidArgumentException;
 
@@ -222,7 +221,7 @@ class SubjectFilter implements SubjectFilterInterface
      *
      *
      */
-    public function subfilter(string $field, string $subClass = ''): FilterInterface
+    public function subfilter(string $field, string $subClass = ''): SubjectFilterInterface
     {
         $class = $subClass !== '' ? $subClass : static::class;
         $spec = $this->sub_spec_factory->newSubSpec($class);

--- a/src/SubjectFilter.php
+++ b/src/SubjectFilter.php
@@ -297,44 +297,10 @@ class SubjectFilter implements SubjectFilterInterface
      */
     protected function applyToArray(array &$array): bool
     {
-        $object = $this->arrayToObject($array);
+        $object = (object) $array;
         $result = $this->applyToObject($object);
-        $array  = $this->objectToArray($object);
+        $array  = (array) $object;
         return $result;
-    }
-
-    /**
-     *
-     * Recursively converts an array to a stdClass object so nested arrays
-     * are accessible as object properties by sub-filters.
-     *
-     * @param array $array The array to convert.
-     *
-     */
-    private function arrayToObject(array $array): object
-    {
-        $obj = new \stdClass();
-        foreach ($array as $key => $value) {
-            $obj->$key = is_array($value) ? $this->arrayToObject($value) : $value;
-        }
-        return $obj;
-    }
-
-    /**
-     *
-     * Recursively converts a stdClass object back to an array so any
-     * sanitized values are written back to the caller's array.
-     *
-     * @param object $obj The object to convert.
-     *
-     */
-    private function objectToArray(object $obj): array
-    {
-        $arr = [];
-        foreach ((array) $obj as $key => $value) {
-            $arr[$key] = is_object($value) ? $this->objectToArray($value) : $value;
-        }
-        return $arr;
     }
 
     /**

--- a/src/SubjectFilter.php
+++ b/src/SubjectFilter.php
@@ -19,6 +19,8 @@ use Aura\Filter\Spec\Spec;
 use Aura\Filter\Spec\ValidateSpec;
 use Aura\Filter\Spec\SubSpecFactory;
 use Aura\Filter\Spec\SubSpec;
+use Aura\Filter_Interface\FilterInterface;
+use Aura\Filter_Interface\SubjectFilterInterface;
 use InvalidArgumentException;
 
 /**
@@ -28,7 +30,7 @@ use InvalidArgumentException;
  * @package Aura.Filter
  *
  */
-class SubjectFilter
+class SubjectFilter implements SubjectFilterInterface
 {
     /**
      *
@@ -220,10 +222,12 @@ class SubjectFilter
      *
      *
      */
-    public function subfilter(string $field, $class = \Aura\Filter\SubjectFilter::class): Spec
+    public function subfilter(string $field, string $subClass = ''): FilterInterface
     {
+        $class = $subClass !== '' ? $subClass : static::class;
         $spec = $this->sub_spec_factory->newSubSpec($class);
-        return $this->addSpec($spec, $field);
+        $this->addSpec($spec, $field);
+        return $spec->filter();
     }
 
     /**
@@ -294,10 +298,44 @@ class SubjectFilter
      */
     protected function applyToArray(array &$array): bool
     {
-        $object = (object) $array;
+        $object = $this->arrayToObject($array);
         $result = $this->applyToObject($object);
-        $array = (array) $object;
+        $array  = $this->objectToArray($object);
         return $result;
+    }
+
+    /**
+     *
+     * Recursively converts an array to a stdClass object so nested arrays
+     * are accessible as object properties by sub-filters.
+     *
+     * @param array $array The array to convert.
+     *
+     */
+    private function arrayToObject(array $array): object
+    {
+        $obj = new \stdClass();
+        foreach ($array as $key => $value) {
+            $obj->$key = is_array($value) ? $this->arrayToObject($value) : $value;
+        }
+        return $obj;
+    }
+
+    /**
+     *
+     * Recursively converts a stdClass object back to an array so any
+     * sanitized values are written back to the caller's array.
+     *
+     * @param object $obj The object to convert.
+     *
+     */
+    private function objectToArray(object $obj): array
+    {
+        $arr = [];
+        foreach ((array) $obj as $key => $value) {
+            $arr[$key] = is_object($value) ? $this->objectToArray($value) : $value;
+        }
+        return $arr;
     }
 
     /**

--- a/tests/SubjectFilterTest.php
+++ b/tests/SubjectFilterTest.php
@@ -378,9 +378,10 @@ class SubjectFilterTest extends TestCase
         $sub = $this->filter->subfilter('address');
         $sub->validate('city')->isNotBlank();
 
-        // 'tags' is a plain array field — its rule receives it as an array
-        $this->filter->validate('tags')->is('callback', function ($value) {
-            return is_array($value);   // must still be an array, not stdClass
+        // 'tags' is a plain array field — its rule receives the whole subject
+        // object; extract the field value and confirm it is still an array.
+        $this->filter->validate('tags')->is('callback', function ($subject, $field) {
+            return is_array($subject->$field);   // must still be an array, not stdClass
         });
 
         $data = [

--- a/tests/SubjectFilterTest.php
+++ b/tests/SubjectFilterTest.php
@@ -311,4 +311,126 @@ class SubjectFilterTest extends TestCase
         $this->assertSame($expect, $actual);
     }
 
+    // ------------------------------------------------------------------
+    // subfilter + nested array tests
+    // ------------------------------------------------------------------
+
+    /**
+     * A nested array field targeted by subfilter() is validated correctly;
+     * a failing nested field surfaces failures on the sub-filter.
+     */
+    public function testSubfilter_nestedArrayValidationFails()
+    {
+        $sub = $this->filter->subfilter('address');
+        $sub->validate('city')->isNotBlank();
+        $sub->validate('zip')->is('alnum');
+
+        $data = ['address' => ['city' => '', 'zip' => '90210']];
+        $result = $this->filter->apply($data);
+
+        $this->assertFalse($result);
+        $messages = $this->filter->getFailures()->getMessages();
+        $this->assertArrayHasKey('city', $messages);
+    }
+
+    /**
+     * A nested array field targeted by subfilter() passes when all rules
+     * are satisfied.
+     */
+    public function testSubfilter_nestedArrayValidationPasses()
+    {
+        $sub = $this->filter->subfilter('address');
+        $sub->validate('city')->isNotBlank();
+        $sub->validate('zip')->is('alnum');
+
+        $data = ['address' => ['city' => 'Beverly Hills', 'zip' => '90210']];
+        $result = $this->filter->apply($data);
+
+        $this->assertTrue($result);
+        $this->assertTrue($this->filter->getFailures()->isEmpty());
+    }
+
+    /**
+     * Sanitize rules inside a subfilter write the sanitized value back
+     * through to the original array.
+     */
+    public function testSubfilter_nestedArraySanitizeWritesBack()
+    {
+        $sub = $this->filter->subfilter('address');
+        $sub->sanitize('city')->to('string');
+        $sub->sanitize('zip')->to('strlenMax', 5);
+
+        $data = ['address' => ['city' => 'Beverly Hills', 'zip' => '902101234']];
+        $result = $this->filter->apply($data);
+
+        $this->assertTrue($result);
+        $this->assertSame('90210', $data['address']['zip']);
+    }
+
+    /**
+     * Array fields that do NOT have a subfilter registered must still reach
+     * their own rules as plain arrays, not as stdClass objects.
+     * Regression guard for the over-broad arrayToObject() fix.
+     */
+    public function testSubfilter_plainArrayFieldUnaffectedBySubfilter()
+    {
+        // Register a subfilter on 'address' only
+        $sub = $this->filter->subfilter('address');
+        $sub->validate('city')->isNotBlank();
+
+        // 'tags' is a plain array field — its rule receives it as an array
+        $this->filter->validate('tags')->is('callback', function ($value) {
+            return is_array($value);   // must still be an array, not stdClass
+        });
+
+        $data = [
+            'tags'    => ['php', 'aura'],
+            'address' => ['city' => 'NYC'],
+        ];
+        $result = $this->filter->apply($data);
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Deeply nested arrays (three levels) are handled correctly by chained
+     * subfilter() calls.
+     */
+    public function testSubfilter_deeplyNestedArray()
+    {
+        $sub     = $this->filter->subfilter('order');
+        $subItem = $sub->subfilter('item');
+        $subItem->validate('name')->isNotBlank();
+
+        $data = ['order' => ['item' => ['name' => '']]];
+        $result = $this->filter->apply($data);
+
+        $this->assertFalse($result);
+
+        // passing case
+        $filter2 = (new FilterFactory())->newSubjectFilter();
+        $s       = $filter2->subfilter('order');
+        $s->subfilter('item')->validate('name')->isNotBlank();
+
+        $data2 = ['order' => ['item' => ['name' => 'Widget']]];
+        $this->assertTrue($filter2->apply($data2));
+    }
+
+    /**
+     * subfilter() on an object field (original pre-fix behaviour) still works.
+     */
+    public function testSubfilter_nestedObjectUnchanged()
+    {
+        $sub = $this->filter->subfilter('address');
+        $sub->validate('city')->isNotBlank();
+
+        $address        = new \stdClass();
+        $address->city  = 'NYC';
+        $subject        = new \stdClass();
+        $subject->address = $address;
+
+        $result = $this->filter->apply($subject);
+        $this->assertTrue($result);
+    }
+
 }


### PR DESCRIPTION
Adding SubjectFilterInterface to Aura.Filter_Interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sanitization now writes back into original nested array/object shapes when using subfilters.

* **Refactor**
  * Core filter components now rely on interface-based contracts for clearer typing and interoperability.

* **Tests**
  * Added coverage for nested-array/object subfilter validation, sanitization, and multi-level chaining.

* **Dependencies**
  * Bumped aura/filter-interface requirement from 4.x-dev to 5.x-dev.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/auraphp/Aura.Filter/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->